### PR TITLE
Add flag to pass all logs to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ More features (like seeing graphs, based on which recommendations were made) com
 | Installation Location 🌍    | ✅ Not required to be installed inside the cluster, can be used on your own device, connected to a cluster | ❌ Must be installed inside the cluster                     |
 | Workload Configuration 🔧   | ✅ No need to configure a VPA object for each workload                                                     | ❌ Requires VPA object configuration for each workload      |
 | Immediate Results ⚡        | ✅ Gets results immediately (given Prometheus is running)                                                  | ❌ Requires time to gather data and provide recommendations |
-| Reporting 📊                | ✅ Detailed CLI Report, web UI in [Robusta.dev](https://home.robusta.dev/)                            | ❌ Not supported                                            |
+| Reporting 📊                | ✅ Detailed CLI Report, web UI in [Robusta.dev](https://home.robusta.dev/)                                 | ❌ Not supported                                            |
 | Extensibility 🔧            | ✅ Add your own strategies with few lines of Python                                                        | :warning: Limited extensibility                             |
 | Custom Metrics 📏           | 🔄 Support in future versions                                                                              | ❌ Not supported                                            |
 | Custom Resources 🎛️         | 🔄 Support in future versions (e.g., GPU)                                                                  | ❌ Not supported                                            |
@@ -165,7 +165,7 @@ sudo apt install robusta-krr
 
 `````sh
 docker pull robusta/krr
-```` 
+````
 
 #### Manual
 
@@ -215,16 +215,16 @@ By default krr will run in the current context. If you want to run it in a diffe
 python krr.py simple -c my-cluster-1 -c my-cluster-2
 ```
 
-If you want to get the output in JSON format (-q is for quiet mode):
+If you want to get the output in JSON format (--logtostderr is required so no logs go to the result file):
 
 ```sh
-python krr.py simple -q -f json > result.json
+python krr.py simple --logtostderr -f json > result.json
 ```
 
 If you want to get the output in YAML format:
 
 ```sh
-python krr.py simple -q -f yaml > result.yaml
+python krr.py simple --logtostderr -f yaml > result.yaml
 ```
 
 If you want to see additional debug logs:
@@ -248,6 +248,7 @@ python krr.py simple --help
 If your prometheus is not auto-connecting, you can use `kubectl port-forward` for manually forwarding Prometheus.
 
 For example, if you have a Prometheus Pod called `kube-prometheus-st-prometheus-0`, then run this command to port-forward it:
+
 ```sh
 kubectl port-forward pod/kube-prometheus-st-prometheus-0 9090
 ```

--- a/robusta_krr/core/models/config.py
+++ b/robusta_krr/core/models/config.py
@@ -34,6 +34,7 @@ class Config(pd.BaseSettings):
     # Logging Settings
     format: str
     strategy: str
+    log_to_stderr: bool
 
     other_args: dict[str, Any]
 

--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -44,7 +44,7 @@ class Runner(Configurable):
     def _process_result(self, result: Result) -> None:
         formatted = result.format(self.config.format)
         self.echo("\n", no_prefix=True)
-        self.console.print(formatted)
+        self.print_result(formatted)
 
     def __get_resource_minimal(self, resource: ResourceType) -> Decimal:
         if resource == ResourceType.CPU:

--- a/robusta_krr/main.py
+++ b/robusta_krr/main.py
@@ -79,6 +79,7 @@ def run() -> None:
                 format: str = typer.Option("table", "--formatter", "-f", help="Output formatter ({formatters})", rich_help_panel="Logging Settings"),
                 verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose mode", rich_help_panel="Logging Settings"),
                 quiet: bool = typer.Option(False, "--quiet", "-q", help="Enable quiet mode", rich_help_panel="Logging Settings"),
+                log_to_stderr: bool = typer.Option(False, "--logtostderr", help="Pass logs to stderr", rich_help_panel="Logging Settings"),
                 {strategy_settings},
             ) -> None:
                 '''Run KRR using the `{func_name}` strategy'''
@@ -92,6 +93,7 @@ def run() -> None:
                     format=format,
                     verbose=verbose,
                     quiet=quiet,
+                    log_to_stderr=log_to_stderr,
                     strategy="{func_name}",
                     other_args={strategy_args},
                 )

--- a/robusta_krr/utils/configurable.py
+++ b/robusta_krr/utils/configurable.py
@@ -6,8 +6,6 @@ from rich.console import Console
 
 from robusta_krr.core.models.config import Config
 
-console = Console()
-
 
 class Configurable(abc.ABC):
     """
@@ -17,7 +15,7 @@ class Configurable(abc.ABC):
 
     def __init__(self, config: Config) -> None:
         self.config = config
-        self.console = console
+        self.console = Console(stderr=self.config.log_to_stderr)
 
     @property
     def debug_active(self) -> bool:
@@ -30,6 +28,13 @@ class Configurable(abc.ABC):
     @staticmethod
     def __add_prefix(text: str, prefix: str, /, no_prefix: bool) -> str:
         return f"{prefix} {text}" if not no_prefix else text
+
+    def print_result(self, content: str) -> None:
+        """
+        Prints the result in a console. The result is always put in stdout.
+        """
+        result_console = Console()
+        result_console.print(content)
 
     def echo(
         self, message: str = "", *, no_prefix: bool = False, type: Literal["INFO", "WARNING", "ERROR"] = "INFO"


### PR DESCRIPTION
As requested in #19, added `--logtostderr` flag for being able to both see logs and get result in a file.