### PR TITLE
Replace decimal to numpy and save time data

### DIFF
--- a/examples/custom_strategy.py
+++ b/examples/custom_strategy.py
@@ -1,7 +1,5 @@
 # This is an example on how to create your own custom strategy
 
-from decimal import Decimal
-
 import pydantic as pd
 
 import robusta_krr
@@ -11,8 +9,8 @@ from robusta_krr.api.strategies import BaseStrategy, StrategySettings
 
 # Providing description to the settings will make it available in the CLI help
 class CustomStrategySettings(StrategySettings):
-    param_1: Decimal = pd.Field(99, gt=0, description="First example parameter")
-    param_2: Decimal = pd.Field(105_000, gt=0, description="Second example parameter")
+    param_1: float = pd.Field(99, gt=0, description="First example parameter")
+    param_2: float = pd.Field(105_000, gt=0, description="Second example parameter")
 
 
 class CustomStrategy(BaseStrategy[CustomStrategySettings]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ line_length = 120
 multi_line_output = 3
 include_trailing_comma = true
 
+[tool.mypy]
+plugins = "numpy.typing.mypy_plugin"
+
 [tool.poetry.scripts]
 krr = "robusta_krr.main:run"
 
@@ -25,6 +28,8 @@ typer = {extras = ["all"], version = "^0.7.0"}
 pydantic = "1.10.7"
 kubernetes = "^26.1.0"
 prometheus-api-client = "^0.5.3"
+numpy = "^1.24.2"
+
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.0.1"

--- a/robusta_krr/core/abstract/strategies.py
+++ b/robusta_krr/core/abstract/strategies.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import abc
 import datetime
-from decimal import Decimal
-from typing import Generic, Optional, TypeVar, get_args
+import numpy as np
+from numpy.typing import NDArray
+from typing import Generic, Optional, TypeVar, get_args, Annotated, Literal
 
 import pydantic as pd
 
@@ -12,8 +13,8 @@ from robusta_krr.utils.display_name import add_display_name
 
 
 class ResourceRecommendation(pd.BaseModel):
-    request: Optional[Decimal]
-    limit: Optional[Decimal]
+    request: Optional[float]
+    limit: Optional[float]
 
 
 class StrategySettings(pd.BaseModel):
@@ -32,7 +33,9 @@ class StrategySettings(pd.BaseModel):
 
 
 _StrategySettings = TypeVar("_StrategySettings", bound=StrategySettings)
-ResourceHistoryData = dict[str, list[Decimal]]
+
+ArrayNx2 = Annotated[NDArray[np.float64], Literal["N", 2]]
+ResourceHistoryData = dict[str, ArrayNx2]
 HistoryData = dict[ResourceType, ResourceHistoryData]
 RunResult = dict[ResourceType, ResourceRecommendation]
 

--- a/robusta_krr/core/integrations/prometheus/loader.py
+++ b/robusta_krr/core/integrations/prometheus/loader.py
@@ -18,6 +18,9 @@ from robusta_krr.utils.service_discovery import ServiceDiscovery
 
 from .metrics import BaseMetricLoader
 
+import numpy as np
+from numpy.typing import NDArray
+
 
 class PrometheusDiscovery(ServiceDiscovery):
     def find_prometheus_url(self, *, api_client: Optional[ApiClient] = None) -> Optional[str]:

--- a/robusta_krr/core/models/allocations.py
+++ b/robusta_krr/core/models/allocations.py
@@ -21,6 +21,7 @@ class ResourceType(str, enum.Enum):
 
 
 RecommendationValue = Union[float, Literal["?"], None]
+RecommendationValueRaw = Union[float, str, None]
 
 Self = TypeVar("Self", bound="ResourceAllocations")
 
@@ -30,7 +31,7 @@ class ResourceAllocations(pd.BaseModel):
     limits: dict[ResourceType, RecommendationValue]
 
     @staticmethod
-    def __parse_resource_value(value: float | str | None) -> RecommendationValue:
+    def __parse_resource_value(value: RecommendationValueRaw) -> RecommendationValue:
         if value is None:
             return None
 
@@ -44,7 +45,7 @@ class ResourceAllocations(pd.BaseModel):
 
     @pd.validator("requests", "limits", pre=True)
     def validate_requests(
-        cls, value: dict[ResourceType, float | str | None]
+        cls, value: dict[ResourceType, RecommendationValueRaw]
     ) -> dict[ResourceType, RecommendationValue]:
         return {
             resource_type: cls.__parse_resource_value(resource_value) for resource_type, resource_value in value.items()

--- a/robusta_krr/core/models/allocations.py
+++ b/robusta_krr/core/models/allocations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import enum
-from decimal import Decimal
+import math
 from typing import Literal, TypeVar, Union
 
 import pydantic as pd
@@ -20,7 +20,7 @@ class ResourceType(str, enum.Enum):
     Memory = "memory"
 
 
-RecommendationValue = Union[Decimal, Literal["?"], None]
+RecommendationValue = Union[float, Literal["?"], None]
 
 Self = TypeVar("Self", bound="ResourceAllocations")
 
@@ -30,21 +30,21 @@ class ResourceAllocations(pd.BaseModel):
     limits: dict[ResourceType, RecommendationValue]
 
     @staticmethod
-    def __parse_resource_value(value: Decimal | str | None) -> RecommendationValue:
+    def __parse_resource_value(value: float | str | None) -> RecommendationValue:
         if value is None:
             return None
 
         if isinstance(value, str):
-            return resource_units.parse(value)
+            return float(resource_units.parse(value))
 
-        if value.is_nan():
+        if math.isnan(value):
             return "?"
 
-        return value
+        return float(value)
 
     @pd.validator("requests", "limits", pre=True)
     def validate_requests(
-        cls, value: dict[ResourceType, Decimal | str | None]
+        cls, value: dict[ResourceType, float | str | None]
     ) -> dict[ResourceType, RecommendationValue]:
         return {
             resource_type: cls.__parse_resource_value(resource_value) for resource_type, resource_value in value.items()

--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -57,6 +57,7 @@ class Runner(Configurable):
         if value is None or math.isnan(value):
             return value
 
+        prec_power: Union[float, int]
         if resource == ResourceType.CPU:
             # NOTE: We use 10**3 as the minimal value for CPU is 1m
             prec_power = 10**3

--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -1,6 +1,5 @@
 import asyncio
 import math
-from decimal import Decimal
 from typing import Optional, Union
 
 from robusta_krr.core.abstract.strategies import ResourceRecommendation, RunResult
@@ -46,32 +45,29 @@ class Runner(Configurable):
         self.echo("\n", no_prefix=True)
         self.print_result(formatted)
 
-    def __get_resource_minimal(self, resource: ResourceType) -> Decimal:
+    def __get_resource_minimal(self, resource: ResourceType) -> float:
         if resource == ResourceType.CPU:
-            return Decimal(1 / 1000) * self.config.cpu_min_value
+            return 1 / 1000 * self.config.cpu_min_value
         elif resource == ResourceType.Memory:
-            return Decimal(1_000_000) * self.config.memory_min_value
+            return 1_000_000 * self.config.memory_min_value
         else:
-            return Decimal(0)
+            return 0
 
-    def _round_value(self, value: Optional[Decimal], resource: ResourceType) -> Optional[Decimal]:
-        if value is None:
+    def _round_value(self, value: Optional[float], resource: ResourceType) -> Optional[float]:
+        if value is None or math.isnan(value):
             return value
-
-        if value.is_nan():
-            return Decimal("nan")
 
         if resource == ResourceType.CPU:
             # NOTE: We use 10**3 as the minimal value for CPU is 1m
-            prec_power = Decimal(10**3)
+            prec_power = 10**3
         elif resource == ResourceType.Memory:
             # NOTE: We use 10**6 as the minimal value for memory is 1M
-            prec_power = 1 / Decimal(10**6)
+            prec_power = 1 / 10**6
         else:
             # NOTE: We use 1 as the minimal value for other resources
-            prec_power = Decimal(1)
+            prec_power = 1
 
-        rounded = Decimal(math.ceil(value * prec_power)) / prec_power
+        rounded = math.ceil(value * prec_power) / prec_power
 
         minimal = self.__get_resource_minimal(resource)
         return max(rounded, minimal)

--- a/robusta_krr/formatters/table.py
+++ b/robusta_krr/formatters/table.py
@@ -12,7 +12,6 @@ from robusta_krr.utils import resource_units
 
 NONE_LITERAL = "none"
 NAN_LITERAL = "?"
-PRESCISION = 4
 ALLOWED_DIFFERENCE = 0.05
 
 
@@ -21,13 +20,13 @@ class TableFormatter(BaseFormatter):
 
     __display_name__ = "table"
 
-    def _format_united_decimal(self, value: RecommendationValue, prescision: Optional[int] = None) -> str:
+    def _format(self, value: RecommendationValue) -> str:
         if value is None:
             return NONE_LITERAL
         elif isinstance(value, str):
             return NAN_LITERAL
         else:
-            return resource_units.format(value, prescision=prescision)
+            return resource_units.format(value)
 
     def _format_request_str(self, item: ResourceScan, resource: ResourceType, selector: str) -> str:
         allocated = getattr(item.object.allocations, selector)[resource]
@@ -36,9 +35,9 @@ class TableFormatter(BaseFormatter):
 
         return (
             f"[{severity.color}]"
-            + self._format_united_decimal(allocated)
+            + self._format(allocated)
             + " -> "
-            + self._format_united_decimal(recommended.value, prescision=PRESCISION)
+            + self._format(recommended.value)
             + f"[/{severity.color}]"
         )
 

--- a/robusta_krr/strategies/simple.py
+++ b/robusta_krr/strategies/simple.py
@@ -26,7 +26,7 @@ class SimpleStrategySettings(StrategySettings):
         if len(data_) == 0:
             return float("NaN")
 
-        return float(max(data_) * (1 + self.memory_buffer_percentage / 100))
+        return max(data_) * (1 + self.memory_buffer_percentage / 100)
 
     def calculate_cpu_proposal(self, data: dict[str, NDArray[np.float64]]) -> float:
         if len(data) == 0:
@@ -37,7 +37,7 @@ class SimpleStrategySettings(StrategySettings):
         else:
             data_ = list(data.values())[0][:, 1]
 
-        return float(np.percentile(data_, self.cpu_percentile))
+        return np.percentile(data_, self.cpu_percentile)
 
 
 class SimpleStrategy(BaseStrategy[SimpleStrategySettings]):

--- a/robusta_krr/strategies/simple.py
+++ b/robusta_krr/strategies/simple.py
@@ -32,8 +32,12 @@ class SimpleStrategySettings(StrategySettings):
         if len(data) == 0:
             return float("NaN")
 
-        data_ = np.concatenate([values[:, 1] for values in data.values()]) if len(data) > 1 else list(data.values())[0]
-        return float(np.percentile(data_, self.cpu_percentile / 100))
+        if len(data) > 1:
+            data_ = np.concatenate([values[:, 1] for values in data.values()])
+        else:
+            data_ = list(data.values())[0][:, 1]
+
+        return float(np.percentile(data_, self.cpu_percentile))
 
 
 class SimpleStrategy(BaseStrategy[SimpleStrategySettings]):

--- a/robusta_krr/strategies/simple.py
+++ b/robusta_krr/strategies/simple.py
@@ -1,6 +1,6 @@
-from decimal import Decimal
-
 import pydantic as pd
+import numpy as np
+from numpy.typing import NDArray
 
 from robusta_krr.core.abstract.strategies import (
     BaseStrategy,
@@ -14,26 +14,26 @@ from robusta_krr.core.abstract.strategies import (
 
 
 class SimpleStrategySettings(StrategySettings):
-    cpu_percentile: Decimal = pd.Field(
+    cpu_percentile: float = pd.Field(
         99, gt=0, le=100, description="The percentile to use for the CPU recommendation."
     )
-    memory_buffer_percentage: Decimal = pd.Field(
+    memory_buffer_percentage: float = pd.Field(
         5, gt=0, description="The percentage of added buffer to the peak memory usage for memory recommendation."
     )
 
-    def calculate_memory_proposal(self, data: dict[str, list[Decimal]]) -> Decimal:
-        data_ = [value for values in data.values() for value in values]
+    def calculate_memory_proposal(self, data: dict[str, NDArray[np.float64]]) -> float:
+        data_ = [np.max(values[:, 1]) for values in data.values()]
         if len(data_) == 0:
-            return Decimal("NaN")
+            return float("NaN")
 
-        return max(data_) * Decimal(1 + self.memory_buffer_percentage / 100)
+        return float(max(data_) * (1 + self.memory_buffer_percentage / 100))
 
-    def calculate_cpu_proposal(self, data: dict[str, list[Decimal]]) -> Decimal:
-        data_ = [value for values in data.values() for value in values]
-        if len(data_) == 0:
-            return Decimal("NaN")
+    def calculate_cpu_proposal(self, data: dict[str, NDArray[np.float64]]) -> float:
+        if len(data) == 0:
+            return float("NaN")
 
-        return data_[int((len(data_) - 1) * self.cpu_percentile / 100)]
+        data_ = np.concatenate([values[:, 1] for values in data.values()]) if len(data) > 1 else list(data.values())[0]
+        return float(np.percentile(data_, self.cpu_percentile / 100))
 
 
 class SimpleStrategy(BaseStrategy[SimpleStrategySettings]):

--- a/robusta_krr/utils/resource_units.py
+++ b/robusta_krr/utils/resource_units.py
@@ -1,48 +1,53 @@
-from decimal import Decimal
-from typing import Optional
+from typing import Literal
 
 UNITS = {
-    "m": Decimal("1e-3"),
-    "Ki": Decimal(1024),
-    "Mi": Decimal(1024**2),
-    "Gi": Decimal(1024**3),
-    "Ti": Decimal(1024**4),
-    "Pi": Decimal(1024**5),
-    "Ei": Decimal(1024**6),
-    "k": Decimal(1e3),
-    "M": Decimal(1e6),
-    "G": Decimal(1e9),
-    "T": Decimal(1e12),
-    "P": Decimal(1e15),
-    "E": Decimal(1e18),
+    "m": 0.001,
+    "Ki": 1024,
+    "Mi": 1024**2,
+    "Gi": 1024**3,
+    "Ti": 1024**4,
+    "Pi": 1024**5,
+    "Ei": 1024**6,
+    "k": 1e3,
+    "M": 1e6,
+    "G": 1e9,
+    "T": 1e12,
+    "P": 1e15,
+    "E": 1e18,
 }
 
 
-def parse(x: str) -> Decimal:
+def parse(x: str, /) -> float | int:
     """Converts a string to an integer with respect of units."""
+
     for unit, multiplier in UNITS.items():
         if x.endswith(unit):
-            return Decimal(x[: -len(unit)]) * multiplier
-    return Decimal(x)
+            return int(x[: -len(unit)]) * multiplier
+    if "." in x:
+        return float(x)
+    return int(x)
 
 
-def format(x: Decimal, prescision: Optional[int] = None) -> str:
+def get_base(x: str, /) -> Literal[1024, 1000]:
+    """Returns the base of the unit."""
+
+    for unit, multiplier in UNITS.items():
+        if x.endswith(unit):
+            return 1024 if unit in ["Ki", "Mi", "Gi", "Ti", "Pi", "Ei"] else 1000
+    return 1000 if "." in x else 1024
+
+
+def format(x: float | int, /, *, base: Literal[1024, 1000] = 1024) -> str:
     """Converts an integer to a string with respect of units."""
 
-    if prescision is not None:
-        # Use inly the first prescision digits, starting from the biggest one
-        # Example? 123456 -> 123000
-        assert prescision >= 0
+    if x < 1:
+        return f"{int(x*1000)}m"
 
-        exponent: int
-        sign, digits, exponent = x.as_tuple()  # type: ignore
-        x = Decimal((sign, list(digits[:prescision]) + [0] * (len(digits) - prescision), exponent))
+    units = ['', 'K', 'M', 'G', 'T', 'P', 'E']
+    binary_units = ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei']
 
-    if x == 0:
-        return "0"
-
-    for unit, multiplier in reversed(UNITS.items()):
-        if x % multiplier == 0:
-            v = int(x / multiplier)
-            return f"{v}{unit}"
-    return str(x)
+    x = int(x)
+    for i, unit in enumerate(binary_units if base == 1024 else units):
+        if x < base**(i + 1) or i == len(units) - 1 or x / base**(i + 1) < 10:
+            return f"{x/base**i:.0f}{unit}"
+    return f"{x/6**i:.0f}{unit}"

--- a/robusta_krr/utils/resource_units.py
+++ b/robusta_krr/utils/resource_units.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Union
 
 UNITS = {
     "m": 0.001,
@@ -17,7 +17,7 @@ UNITS = {
 }
 
 
-def parse(x: str, /) -> float | int:
+def parse(x: str, /) -> Union[float, int]:
     """Converts a string to an integer with respect of units."""
 
     for unit, multiplier in UNITS.items():
@@ -37,7 +37,7 @@ def get_base(x: str, /) -> Literal[1024, 1000]:
     return 1000 if "." in x else 1024
 
 
-def format(x: float | int, /, *, base: Literal[1024, 1000] = 1024) -> str:
+def format(x: Union[float, int], /, *, base: Literal[1024, 1000] = 1024) -> str:
     """Converts an integer to a string with respect of units."""
 
     if x < 1:


### PR DESCRIPTION
Loading additional data for older pods resulted in data, passed to strategy missing timestamp data, so no information about time relativity is preserved.

Additionally, replaces all Decimals to numpy.ndarray to speedup calculations and to get a cleaner calculations.

Merge only after https://github.com/robusta-dev/krr/pull/33