### PR TITLE
Support filtering by resource type, and more focused namespace retrieval. 

### DIFF
--- a/robusta_krr/core/models/config.py
+++ b/robusta_krr/core/models/config.py
@@ -26,6 +26,7 @@ class Config(pd.BaseSettings):
 
     clusters: Union[list[str], Literal["*"], None] = None
     namespaces: Union[list[str], Literal["*"]] = pd.Field("*")
+    resources: Union[list[str], Literal["*"]] = pd.Field("*")
 
     # Value settings
     cpu_min_value: int = pd.Field(5, ge=0)  # in millicores
@@ -49,6 +50,13 @@ class Config(pd.BaseSettings):
 
     @pd.validator("namespaces")
     def validate_namespaces(cls, v: Union[list[str], Literal["*"]]) -> Union[list[str], Literal["*"]]:
+        if v == []:
+            return "*"
+
+        return v
+
+    @pd.validator("resources")
+    def validate_resources(cls, v: Union[list[str], Literal["*"]]) -> Union[list[str], Literal["*"]]:
         if v == []:
             return "*"
 

--- a/robusta_krr/main.py
+++ b/robusta_krr/main.py
@@ -57,6 +57,13 @@ def load_commands() -> None:
                     help="List of namespaces to run on. By default, will run on all namespaces.",
                     rich_help_panel="Kubernetes Settings"
                 ),
+                resources: List[str] = typer.Option(
+                    None,
+                    "--resource",
+                    "-n",
+                    help="List of resources to run on. By default, will run on all resources.",
+                    rich_help_panel="Kubernetes Settings"
+                ),
                 prometheus_url: Optional[str] = typer.Option(
                     None,
                     "--prometheus-url",
@@ -87,6 +94,7 @@ def load_commands() -> None:
                 config = Config(
                     clusters="*" if "*" in clusters else clusters,
                     namespaces="*" if "*" in namespaces else namespaces,
+                    resources="*" if "*" in resources else resources,
                     prometheus_url=prometheus_url,
                     prometheus_auth_header=prometheus_auth_header,
                     prometheus_ssl_enabled=prometheus_ssl_enabled,


### PR DESCRIPTION
This allows non-admin users on RBAC enforced clusters to run krr.

It does this by:

- Adding a new CLI flag called "resources" which allows users to only
  run krr on specific resources.

- Using the `_namespaced_` functions in the k8s python client library
  where specific namespaces are being queried.