### PR TITLE
Fixed prometheus error

### DIFF
--- a/robusta_krr/core/integrations/prometheus/loader.py
+++ b/robusta_krr/core/integrations/prometheus/loader.py
@@ -130,7 +130,8 @@ class PrometheusLoader(Configurable):
         if len(object.pods) == 0:
             return
         
-        days_literal = min(int(period.total_seconds()) // 60 // 24, 32) # the max can be 32 days
+        # Prometheus limit, the max can be 32 days
+        days_literal = min(int(period.total_seconds()) // 60 // 24, 32) 
         period_literal = f"{days_literal}d"
         owner = await asyncio.to_thread(
             self.prometheus.custom_query,

--- a/robusta_krr/core/integrations/prometheus/loader.py
+++ b/robusta_krr/core/integrations/prometheus/loader.py
@@ -129,8 +129,9 @@ class PrometheusLoader(Configurable):
 
         if len(object.pods) == 0:
             return
-
-        period_literal = f"{int(period.total_seconds()) // 60 // 24}d"
+        
+        days_literal = min(int(period.total_seconds()) // 60 // 24, 32) # the max can be 32 days
+        period_literal = f"{days_literal}d"
         owner = await asyncio.to_thread(
             self.prometheus.custom_query,
             query=f'kube_pod_owner{{pod="{next(iter(object.pods)).name}"}}[{period_literal}]',


### PR DESCRIPTION
when running this locally It was returning 840 days and prometheus was getting this error
```
PrometheusApiClientException: HTTP Status Code 400 (b'{"status":"error","errorType":"Bad Request","error":"Bad Request: Invalid time range. Timestamps must be valid and time range cannot exceed 32 days.. RequestId: 
e3fee8436abe2b523b773e1bdbf29d07"}')

```