### PR TITLE
fix bug only collect one pod series per container

### DIFF
--- a/robusta_krr/core/integrations/prometheus/metrics/base_filtered_metric.py
+++ b/robusta_krr/core/integrations/prometheus/metrics/base_filtered_metric.py
@@ -17,7 +17,7 @@ class BaseFilteredMetricLoader(BaseMetricLoader):
 
     @staticmethod
     def get_target_name(series: PrometheusSeries) -> Optional[str]:
-        for label in ["container", "pod", "node"]:
+        for label in [ "pod","container", "node"]:
             if label in series["metric"]:
                 return series["metric"][label]
         return None

--- a/robusta_krr/core/integrations/prometheus/metrics/base_filtered_metric.py
+++ b/robusta_krr/core/integrations/prometheus/metrics/base_filtered_metric.py
@@ -17,7 +17,7 @@ class BaseFilteredMetricLoader(BaseMetricLoader):
 
     @staticmethod
     def get_target_name(series: PrometheusSeries) -> Optional[str]:
-        for label in [ "pod","container", "node"]:
+        for label in ["pod", "container", "node"]:
             if label in series["metric"]:
                 return series["metric"][label]
         return None


### PR DESCRIPTION
Bug explained
we query for metric A on container B for pods X,Y,Z
in function `filter_prom_jobs_results` the bug caused us to only process the results of one pod instead of all of the relevant pods