### PR TITLE
bugfix: parsing of float resources with units

### DIFF
--- a/robusta_krr/utils/resource_units.py
+++ b/robusta_krr/utils/resource_units.py
@@ -22,7 +22,7 @@ def parse(x: str, /) -> Union[float, int]:
 
     for unit, multiplier in UNITS.items():
         if x.endswith(unit):
-            return int(x[: -len(unit)]) * multiplier
+            return float(x[: -len(unit)]) * multiplier
     if "." in x:
         return float(x)
     return int(x)


### PR DESCRIPTION
Hey Robusta! 
We have encountered some "edge-case" where we had a problem due to a deployment having `0.2Gi` as one of its containers memory request.

This is how the error looks like:
```
[ERROR] Error trying to list pods in mycluster: 1 validation error for ResourceAllocations
requests
  invalid literal for int() with base 10: '0.2' (type=value_error)
```

the full error traceback:
```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /Users/arnold.yahad/git/krr/robusta_krr/core/integrations/kubernetes.py:52 in                    │
│ list_scannable_objects                                                                           │
│                                                                                                  │
│    49 │   │   self.debug(f"Namespaces: {self.config.namespaces}")                                │
│    50 │   │                                                                                      │
│    51 │   │   try:                                                                               │
│ ❱  52 │   │   │   objects_tuple = await asyncio.gather(                                          │
│    53                 self._list_deployments(),                                                  │
│    55                 self._list_all_statefulsets(),                                             │
│                                                                                                  │
│ /Users/arnold.yahad/git/krr/robusta_krr/core/integrations/kubernetes.py:138 in _list_rollouts    │
│                                                                                                  │
│   135 │   │   ret: V1DeploymentList = await asyncio.to_thread(self.rollout.list_rollout_for_al   │
│   136 │   │   self.debug(f"Found {len(ret.items)} rollouts in {self.cluster}")                   │
│   137 │   │                                                                                      │
│ ❱ 138 │   │   return await asyncio.gather(                                                       │
│   139 │   │   │   *[                                                                             │
│   140 │   │   │   │   self.__build_obj(item, container)                                          │
│   141 │   │   │   │   for item in ret.items                                                      │
│                                                                                                  │
│ /Users/arnold.yahad/git/krr/robusta_krr/core/integrations/kubernetes.py:117 in __build_obj       │
│                                                                                                  │
│   114 │   │   │   name=item.metadata.name,                                                       │
│   115 │   │   │   kind=item.__class__.__name__[2:],                                              │
│   116 │   │   │   container=container.name,                                                      │
│ ❱ 117 │   │   │   allocations=ResourceAllocations.from_container(container),                     │
│   118 │   │   │   pods=await self.__list_pods(item),                                             │
│   119 │   │   )                                                                                  │
│   120                                                                                            │
│                                                                                                  │
│ /Users/arnold.yahad/git/krr/robusta_krr/core/models/allocations.py:65 in from_container          │
│                                                                                                  │
│   62 │   │   │   The resource allocations.                                                       │
│   63 │   │   """                                                                                 │
│   64 │   │                                                                                       │
│ ❱ 65 │   │   return cls(                                                                         │
│   66 │   │   │   requests={                                                                      │
│   67 │   │   │   │   ResourceType.CPU: container.resources.requests.get("cpu")                   │
│   68 │   │   │   │   if container.resources and container.resources.requests                     │
│                                                                                                  │
│ /Users/arnold.yahad/git/krr/pydantic/main.py:341 in pydantic.main.BaseModel.__init__             │
│
```


when trying to debug it, i saw that this function:
```
    for unit, multiplier in UNITS.items():
        if x.endswith(unit):
            return int(x[: -len(unit)]) * multiplier
```
Is checking if the resource has unites or not, and if it does, it will try to multiple it by the multiplier and return an int.
and for some cases it will work:
for example:
`0.5Gi => 0.5 * 1024**3 = 536,870,912` which is possible to do `int` function on.
but for 0.2GI: 
`0.2Gi => 0.2 * 1024**3 = 214,748,364.8` and this is why it fails, because its a float.





