### PR TITLE
Set default value of prometheus_label to None

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,13 +340,7 @@ If your Prometheus monitors multiple clusters we require the label you defined f
 For example, if your cluster has the Prometheus label `cluster: "my-cluster-name"` and your prometheus is at url `http://my-centralized-prometheus:9090`, then run this command:
 
 ```sh
-krr.py simple -p http://my-centralized-prometheus:9090 -l my-cluster-name
-```
-
-If you are using a label for your cluster other than `cluster` for example the label `env: "dev-tests"` you can specify it by running:
-
-```sh
-krr.py simple -p http://my-centralized-prometheus:9090 --prometheus-label env -l dev-tests
+krr.py simple -p http://my-centralized-prometheus:9090 --prometheus-label cluster -l my-cluster-name
 ```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
+++ b/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
@@ -117,6 +117,9 @@ class PrometheusMetricsService(MetricsService):
         return await loop.run_in_executor(self.executor, lambda: self.prometheus.custom_query(query=query))
 
     def validate_cluster_name(self):
+        if not self.config.prometheus_cluster_label and not self.config.prometheus_label:
+            return
+
         cluster_label = self.config.prometheus_cluster_label
         cluster_names = self.get_cluster_names()
 

--- a/robusta_krr/core/models/config.py
+++ b/robusta_krr/core/models/config.py
@@ -26,7 +26,7 @@ class Config(pd.BaseSettings):
     prometheus_auth_header: Optional[str] = pd.Field(None)
     prometheus_ssl_enabled: bool = pd.Field(False)
     prometheus_cluster_label: Optional[str] = pd.Field(None)
-    prometheus_label: str = pd.Field("cluster")
+    prometheus_label: Optional[str] = pd.Field(None)
 
     # Threading settings
     max_workers: int = pd.Field(6, ge=1)

--- a/robusta_krr/main.py
+++ b/robusta_krr/main.py
@@ -99,7 +99,7 @@ def load_commands() -> None:
                     rich_help_panel="Prometheus Settings",
                 ),
                 prometheus_label: str = typer.Option(
-                    'cluster',
+                    None,
                     "--prometheus-label",
                     help="The label in prometheus used to differentiate clusters. (Only relevant for centralized prometheus)",
                     rich_help_panel="Prometheus Settings",


### PR DESCRIPTION
krr calls [prometheus.get_label_values](https://github.com/robusta-dev/krr/blob/main/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py#L138) function to get a list of all values for the specific label (the default label name is **"cluster"**) to determine whether Prometheus monitors multiple clusters.

However, some metrics may contain the "**cluster**" label, but it doesn't mean that Prometheus monitors multiple clusters. For example, the cluster label in the following metric refers to the Elasticsearch cluster instead of the Kubernetes cluster.

```bash
elasticsearch_cluster_health_status{cluster="elasticsearch-1", color="green", instance="100.96.0.17:9108", job="kubernetes-service-endpoints", kubernetes_node="node-1", namespace="elastic"}
```
When I run `krr simple`, I will get this error:
```bash
[ERROR] No label specified, Rerun krr with the flag `-l <cluster>` where <cluster> is one of ['elasticsearch-1', 'elasticsearch-2', 'elasticsearch-3']
```

So I modified the default value of prometheus_label to None in order to prevent multiple cluster checks by default. If the user needs to handle multi-cluster scenarios, they can explicitly specify the **"cluster"** field.