### PR TITLE
Label selector argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ If you want only specific namespaces (default and ingress-nginx):
 krr simple -n default -n ingress-nginx
 ```
 
+Filtering by labels (more info [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api)):
+
+```sh
+python krr.py simple --selector 'app.kubernetes.io/instance in (robusta, ingress-nginx)'
+```
+
 By default krr will run in the current context. If you want to run it in a different context:
 
 ```sh

--- a/robusta_krr/core/integrations/kubernetes.py
+++ b/robusta_krr/core/integrations/kubernetes.py
@@ -143,7 +143,11 @@ class ClusterLoader(Configurable):
         self.debug(f"Listing deployments in {self.cluster}")
         loop = asyncio.get_running_loop()
         ret: V1DeploymentList = await loop.run_in_executor(
-            self.executor, lambda: self.apps.list_deployment_for_all_namespaces(watch=False)
+            self.executor,
+            lambda: self.apps.list_deployment_for_all_namespaces(
+                watch=False,
+                label_selector=self.config.selector,
+            ),
         )
         self.debug(f"Found {len(ret.items)} deployments in {self.cluster}")
 
@@ -156,8 +160,16 @@ class ClusterLoader(Configurable):
         )
 
     async def _list_rollouts(self) -> list[K8sObjectData]:
+        self.debug(f"Listing ArgoCD rollouts in {self.cluster}")
+        loop = asyncio.get_running_loop()
         try:
-            ret: V1DeploymentList = await asyncio.to_thread(self.rollout.list_rollout_for_all_namespaces, watch=False)
+            ret: V1DeploymentList = await loop.run_in_executor(
+                self.executor,
+                lambda: self.rollout.list_rollout_for_all_namespaces(
+                    watch=False,
+                    label_selector=self.config.selector,
+                ),
+            )
         except ApiException as e:
             if e.status == 404:
                 self.debug(f"Rollout API not available in {self.cluster}")
@@ -178,7 +190,11 @@ class ClusterLoader(Configurable):
         self.debug(f"Listing statefulsets in {self.cluster}")
         loop = asyncio.get_running_loop()
         ret: V1StatefulSetList = await loop.run_in_executor(
-            self.executor, lambda: self.apps.list_stateful_set_for_all_namespaces(watch=False)
+            self.executor,
+            lambda: self.apps.list_stateful_set_for_all_namespaces(
+                watch=False,
+                label_selector=self.config.selector,
+            ),
         )
         self.debug(f"Found {len(ret.items)} statefulsets in {self.cluster}")
 
@@ -194,7 +210,11 @@ class ClusterLoader(Configurable):
         self.debug(f"Listing daemonsets in {self.cluster}")
         loop = asyncio.get_running_loop()
         ret: V1DaemonSetList = await loop.run_in_executor(
-            self.executor, lambda: self.apps.list_daemon_set_for_all_namespaces(watch=False)
+            self.executor,
+            lambda: self.apps.list_daemon_set_for_all_namespaces(
+                watch=False,
+                label_selector=self.config.selector,
+            ),
         )
         self.debug(f"Found {len(ret.items)} daemonsets in {self.cluster}")
 
@@ -210,7 +230,11 @@ class ClusterLoader(Configurable):
         self.debug(f"Listing jobs in {self.cluster}")
         loop = asyncio.get_running_loop()
         ret: V1JobList = await loop.run_in_executor(
-            self.executor, lambda: self.batch.list_job_for_all_namespaces(watch=False)
+            self.executor,
+            lambda: self.batch.list_job_for_all_namespaces(
+                watch=False,
+                label_selector=self.config.selector,
+            ),
         )
         self.debug(f"Found {len(ret.items)} jobs in {self.cluster}")
 
@@ -228,7 +252,11 @@ class ClusterLoader(Configurable):
         self.debug(f"Listing pods in {self.cluster}")
         loop = asyncio.get_running_loop()
         ret: V1PodList = await loop.run_in_executor(
-            self.executor, lambda: self.apps.list_pod_for_all_namespaces(watch=False)
+            self.executor,
+            lambda: self.apps.list_pod_for_all_namespaces(
+                watch=False,
+                label_selector=self.config.selector,
+            ),
         )
         self.debug(f"Found {len(ret.items)} pods in {self.cluster}")
 

--- a/robusta_krr/core/models/config.py
+++ b/robusta_krr/core/models/config.py
@@ -16,6 +16,7 @@ class Config(pd.BaseSettings):
     clusters: Union[list[str], Literal["*"], None] = None
     kubeconfig: Optional[str] = None
     namespaces: Union[list[str], Literal["*"]] = pd.Field("*")
+    selector: Optional[str] = None
 
     # Value settings
     cpu_min_value: int = pd.Field(5, ge=0)  # in millicores

--- a/robusta_krr/main.py
+++ b/robusta_krr/main.py
@@ -72,6 +72,12 @@ def load_commands() -> None:
                     help="List of namespaces to run on. By default, will run on all namespaces.",
                     rich_help_panel="Kubernetes Settings"
                 ),
+                selector: Optional[str] = typer.Option(
+                    None,
+                    "--selector",
+                    help="Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.",
+                    rich_help_panel="Kubernetes Settings"
+                ),
                 prometheus_url: Optional[str] = typer.Option(
                     None,
                     "--prometheus-url",
@@ -123,6 +129,7 @@ def load_commands() -> None:
                     kubeconfig=kubeconfig,
                     clusters="*" if all_clusters else clusters,
                     namespaces="*" if "*" in namespaces else namespaces,
+                    selector=selector,
                     prometheus_url=prometheus_url,
                     prometheus_auth_header=prometheus_auth_header,
                     prometheus_ssl_enabled=prometheus_ssl_enabled,

--- a/robusta_krr/main.py
+++ b/robusta_krr/main.py
@@ -75,7 +75,8 @@ def load_commands() -> None:
                 selector: Optional[str] = typer.Option(
                     None,
                     "--selector",
-                    help="Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.",
+                    "-s",
+                    help="Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -s key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.",
                     rich_help_panel="Kubernetes Settings"
                 ),
                 prometheus_url: Optional[str] = typer.Option(


### PR DESCRIPTION
Added label selector to filter out what exact objects to scan, a proposed by @dohnto-s1 

Added as `--selector`, because `-l` (the same as in kubectl) is already occupied

Will close #62 