### PR TITLE
Prioritize loading user-specified kubeconfig

### DIFF
--- a/robusta_krr/core/integrations/kubernetes.py
+++ b/robusta_krr/core/integrations/kubernetes.py
@@ -255,7 +255,7 @@ class KubernetesLoader(Configurable):
             return None
 
         try:
-            contexts, current_context = config.list_kube_config_contexts()
+            contexts, current_context = config.list_kube_config_contexts(self.config.kubeconfig)
         except config.ConfigException:
             if self.config.clusters is not None and self.config.clusters != "*":
                 self.warning("Could not load context from kubeconfig.")


### PR DESCRIPTION
krr allows the user to specify the kubeconfig file by setting the parameter `--kubeconfig`. However, even though the user specifies the kubeconfig, krr still searches for cluster in the default kubeconfig file(~/.kube/config)

```bash
krr simple -v --kubeconfig ~/tmp/cluster-6.yaml
# output
[DEBUG] Found 5 clusters: cluster-1, cluster-2, cluster-3, cluster-4, cluster-5
```

I added **self.config.kubeconfig** as the argument when calling the `list_kube_config_contexts` function. If the user has specified the kubeconfig, krr will search for the cluster in the user-specified kubeconfig. If not, krr will search for the cluster in the default kubeconfig.
