### PR TITLE
fix(prometheus): Avoid appending duplicate pods

### DIFF
--- a/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
+++ b/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
@@ -226,7 +226,7 @@ class PrometheusMetricsService(MetricsService):
         current_pods_set = {pod["metric"]["pod"] for pod in current_pods}
         del current_pods
 
-        object.pods += [
+        object.pods += set([
             PodData(name=pod["metric"]["pod"], deleted=pod["metric"]["pod"] not in current_pods_set)
             for pod in related_pods
-        ]
+        ])


### PR DESCRIPTION
Hi, I noticed an incorrect pod count that causes incorrect results. I fixed the issue in this PR by simply converting the pod list to a `set`.

Here's my results before and after the fix:
```bash
❯ yq '.scans | map(select(.object.name == "node-exporter")) | .[0].object.pods | map(select(.deleted == false)) | length' before.yml
27
❯ yq '.scans | map(select(.object.name == "node-exporter")) | .[0].object.pods | map(select(.deleted == false)) | length' after.yml
8
❯ kubectl -n monitoring get pods | grep node-exporter | wc -l
8
```

Without filtering out deleted pods:
```bash
❯ yq '.scans | map(select(.object.name == "node-exporter")) | .[0].object.pods | length' before.yml
153
❯ yq '.scans | map(select(.object.name == "node-exporter")) | .[0].object.pods | length' after.yml
42
```
