### PR TITLE
Add additional logs when prometheus not found

### DIFF
--- a/robusta_krr/core/integrations/prometheus/loader.py
+++ b/robusta_krr/core/integrations/prometheus/loader.py
@@ -71,8 +71,8 @@ class PrometheusMetricsLoader(Configurable):
                 self.echo(f"{service_name} found")
                 loader.validate_cluster_name()
                 return loader
-            except MetricsNotFound:
-                self.debug(f"{service_name} not found")
+            except MetricsNotFound as e:
+                self.debug(f"{service_name} not found: {e}")
 
         return None
 


### PR DESCRIPTION
No information was shown if connection to found prometheus was failed, making it impossible to understand what's wrong