### PR TITLE
Rework current pods query to filter finished ones

### DIFF
--- a/robusta_krr/utils/batched.py
+++ b/robusta_krr/utils/batched.py
@@ -1,0 +1,15 @@
+import itertools
+from typing import Iterable, TypeVar
+
+
+_T = TypeVar("_T")
+
+
+def batched(iterable: Iterable[_T], n: int) -> Iterable[list[_T]]:
+    "Batch data into tuples of length n. The last batch may be shorter."
+    # batched('ABCDEFG', 3) --> ABC DEF G
+    if n < 1:
+        raise ValueError("n must be at least one")
+    it = iter(iterable)
+    while batch := list(itertools.islice(it, n)):
+        yield batch


### PR DESCRIPTION
Previous algorithm of finding if the pod is current was not taking into account that it might be running, but in Failed state.

Reworked that for using `kube_pod_status_phase` metric