### PR TITLE
feat(VictoriaMetricsDiscovery): set correct url for cluster version

### DIFF
--- a/robusta_krr/core/integrations/prometheus/metrics_service/victoria_metrics_service.py
+++ b/robusta_krr/core/integrations/prometheus/metrics_service/victoria_metrics_service.py
@@ -17,14 +17,21 @@ class VictoriaMetricsDiscovery(MetricsServiceDiscovery):
         Returns:
             Optional[str]: The discovered Victoria Metrics URL, or None if not found.
         """
-        return super().find_url(
+        url = super().find_url(
             selectors=[
                 "app.kubernetes.io/name=vmsingle",
                 "app.kubernetes.io/name=victoria-metrics-single",
-                "app.kubernetes.io/name=vmselect",
-                "app=vmselect",
             ]
         )
+        if url is None:
+            url = super().find_url(
+                selectors=[
+                    "app.kubernetes.io/name=vmselect",
+                    "app=vmselect",
+                ]
+            )
+            url = f"{url}/select/0/prometheus/"
+        return url
 
 
 class VictoriaMetricsService(PrometheusMetricsService):


### PR DESCRIPTION
Using victoriametrics cluster version will fail due to it needing a different url. 