### PR TITLE
Fix wrong memory buffer percentage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ By default, we use a _simple_ strategy to calculate resource recommendations. It
 
 - For CPU, we set a request at the 99th percentile with no limit. Meaning, in 99% of the cases, your CPU request will be sufficient. For the remaining 1%, we set no limit. This means your pod can burst and use any CPU available on the node - e.g. CPU that other pods requested but aren’t using right now.
 
-- For memory, we take the maximum value over the past week and add a 5% buffer.
+- For memory, we take the maximum value over the past week and add a 15% buffer.
 
 ### Prometheus connection
 


### PR DESCRIPTION
In the [README](https://github.com/robusta-dev/krr?tab=readme-ov-file#algorithm), it is stated that `For memory, we take the maximum value over the past week and add a 5% buffer`. 

However, krr use 15% by default for memory buffer percentage, as stated [here](https://github.com/robusta-dev/krr/blob/acb4aa462a22684c744fa559d2311bd9ac3a8c54/robusta_krr/strategies/simple.py#L25) in the code. 