### PR TITLE
feat: cli option for --as-group

### DIFF
--- a/robusta_krr/core/models/config.py
+++ b/robusta_krr/core/models/config.py
@@ -24,6 +24,7 @@ class Config(pd.BaseSettings):
     clusters: Union[list[str], Literal["*"], None] = None
     kubeconfig: Optional[str] = None
     impersonate_user: Optional[str] = None
+    impersonate_group: Optional[str] = None
     namespaces: Union[list[str], Literal["*"]] = pd.Field("*")
     resources: Union[list[KindLiteral], Literal["*"]] = pd.Field("*")
     selector: Optional[str] = None
@@ -93,7 +94,7 @@ class Config(pd.BaseSettings):
             return "*"
 
         return [val.capitalize() for val in v]
-    
+
 
     @pd.validator("format")
     def validate_format(cls, v: str) -> str:
@@ -130,6 +131,8 @@ class Config(pd.BaseSettings):
         if self.impersonate_user is not None:
             # trick copied from https://github.com/kubernetes-client/python/issues/362
             api_client.set_default_header("Impersonate-User", self.impersonate_user)
+        if self.impersonate_group is not None:
+            api_client.set_default_header("Impersonate-Group", self.impersonate_group)
         return api_client
 
     @staticmethod

--- a/robusta_krr/main.py
+++ b/robusta_krr/main.py
@@ -46,7 +46,7 @@ def version() -> None:
 @app.command(name="simple", rich_help_panel="Strategies")
 def run_simple(
     # For new CLI options, use "--dashes-like-this" and "--not_undersores_like_this"
-    # For backwards compatibility, some CLI options support both styles  
+    # For backwards compatibility, some CLI options support both styles
     kubeconfig: Optional[str] = typer.Option(
         None,
         "--kubeconfig",
@@ -58,6 +58,12 @@ def run_simple(
         None,
         "--as",
         help="Impersonate a user, just like `kubectl --as`. For example, system:serviceaccount:default:krr-account.",
+        rich_help_panel="Kubernetes Settings",
+    ),
+        impersonate_group: Optional[str] = typer.Option(
+        None,
+        "--as-group",
+        help="Impersonate a user inside of a group, just like `kubectl --as-group`. For example, system:authenticated.",
         rich_help_panel="Kubernetes Settings",
     ),
     clusters: List[str] = typer.Option(
@@ -265,6 +271,7 @@ def run_simple(
         config = Config(
             kubeconfig=kubeconfig,
             impersonate_user=impersonate_user,
+            impersonate_group=impersonate_group,
             clusters="*" if all_clusters else clusters,
             namespaces="*" if "*" in namespaces else namespaces,
             resources="*" if "*" in resources else resources,

--- a/tests/single_namespace_as_group.yaml
+++ b/tests/single_namespace_as_group.yaml
@@ -1,0 +1,38 @@
+# Test environment for per-namespace scans using a group object ID (for e.g. Microsoft Entra)
+# The purpose of this setup is to verify that per-namespace features work without cluster level permissions
+# You can test this Group and KRR using:
+# A user named aksdev that's part of the appdev group.
+# krr simple --as aksdev --as-group <appdev-groupID> -n kube-system
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: krr-role
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: krr-role-binding
+  namespace: kube-system
+subjects:
+- kind: Group
+  # Replace <appdev-groupID> with the actual Group Object ID
+  name: <appdev-groupID>
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: krr-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Add --as-group CLI flag if users are not using a group instead of a service account when using per-namespace features

part-of https://github.com/robusta-dev/krr/pull/220