### PR TITLE
Live introduction message

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -85,6 +85,7 @@ jobs:
         pyinstaller krr.py
         mkdir -p ./dist/krr/grapheme/data
         cp $(python -c "import grapheme; print(grapheme.__path__[0] + '/data/grapheme_break_property.json')") ./dist/krr/grapheme/data/grapheme_break_property.json
+        cp ./intro.txt ./dist/krr/intro.txt
 
     - name: Zip the application (Unix)
       if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'

--- a/intro.txt
+++ b/intro.txt
@@ -5,7 +5,8 @@
 |  _  // _ \| '_ \| | | / __| __/ _` | |  < |  _  /|  _  /
 | | \ \ (_) | |_) | |_| \__ \ || (_| | | . \| | \ \| | \ \
 |_|  \_\___/|_.__/ \__,_|___/\__\__,_| |_|\_\_|  \_\_|  \_\
-[/bold magenta]
+
 
 Thanks for using Robusta KRR. If you have any questions or feedback, please feel free to reach out to us at
 https://github.com/robusta-dev/krr/issues
+[/bold magenta]

--- a/intro.txt
+++ b/intro.txt
@@ -1,4 +1,3 @@
-ASCII_LOGO = r"""
 [bold magenta]
  _____       _               _          _  _______  _____
 |  __ \     | |             | |        | |/ /  __ \|  __ \
@@ -8,4 +7,5 @@ ASCII_LOGO = r"""
 |_|  \_\___/|_.__/ \__,_|___/\__\__,_| |_|\_\_|  \_\_|  \_\
 [/bold magenta]
 
-"""
+Thanks for using Robusta KRR. If you have any questions or feedback, please feel free to reach out to us at
+https://github.com/robusta-dev/krr/issues

--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -17,7 +17,7 @@ from robusta_krr.core.integrations.prometheus import ClusterNotSpecifiedExceptio
 from robusta_krr.core.models.config import settings
 from robusta_krr.core.models.objects import K8sObjectData
 from robusta_krr.core.models.result import ResourceAllocations, ResourceScan, ResourceType, Result, StrategyData
-from robusta_krr.utils.logo import ASCII_LOGO
+from robusta_krr.utils.intro import load_intro_message
 from robusta_krr.utils.progress_bar import ProgressBar
 from robusta_krr.utils.version import get_version
 
@@ -65,12 +65,14 @@ class Runner:
 
         return result
 
-    def _greet(self) -> None:
+    async def _greet(self) -> None:
         if settings.quiet:
             return
 
-        custom_print(ASCII_LOGO)
-        custom_print(f"Running Robusta's KRR (Kubernetes Resource Recommender) {get_version()}")
+        intro_message = await load_intro_message()
+
+        custom_print(intro_message)
+        custom_print(f"\nRunning Robusta's KRR (Kubernetes Resource Recommender) {get_version()}")
         custom_print(f"Using strategy: {self._strategy}")
         custom_print(f"Using formatter: {settings.format}")
         custom_print("")
@@ -275,7 +277,7 @@ class Runner:
         )
 
     async def run(self) -> None:
-        self._greet()
+        await self._greet()
 
         try:
             settings.load_kubeconfig()

--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -78,7 +78,7 @@ class Runner:
             if current_version_parsed < latest_version_parsed:
                 return True
         except Exception:
-            logger.exception("An error occurred while checking for a new version")
+            logger.debug("An error occurred while checking for a new version", exc_info=True)
             return False
 
     async def _greet(self) -> None:
@@ -90,12 +90,10 @@ class Runner:
 
         custom_print(intro_message)
         custom_print(f"\nRunning Robusta's KRR (Kubernetes Resource Recommender) {current_version}")
-
-        if latest_version is not None and self.__check_newer_version_available(current_version, latest_version):
-            custom_print(f"[yellow bold]A newer version of KRR is available: {latest_version}[/yellow bold]")
-
         custom_print(f"Using strategy: {self._strategy}")
         custom_print(f"Using formatter: {settings.format}")
+        if latest_version is not None and self.__check_newer_version_available(current_version, latest_version):
+            custom_print(f"[yellow bold]A newer version of KRR is available: {latest_version}[/yellow bold]")
         custom_print("")
 
     def _process_result(self, result: Result) -> None:

--- a/robusta_krr/utils/intro.py
+++ b/robusta_krr/utils/intro.py
@@ -1,0 +1,34 @@
+import requests
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+
+ONLINE_LINK = 'https://github.com/robusta-dev/krr/blob/main/intro.txt'
+LOCAL_LINK = './intro.txt'
+TIMEOUT = 0.5
+
+
+# Synchronous function to fetch intro message
+def fetch_intro_message() -> str:
+    try:
+        # Attempt to get the message from the URL
+        response = requests.get(ONLINE_LINK, timeout=TIMEOUT)
+        response.raise_for_status()  # Raises an error for bad responses
+        return response.text
+    except Exception:
+        # If there's any error, fallback to local file
+        try:
+            with open(LOCAL_LINK, 'r') as file:
+                return file.read()
+        except Exception as e:
+            raise Exception("Failed to load the intro message from both URL and local file.") from e
+
+
+async def load_intro_message() -> str:
+    loop = asyncio.get_running_loop()
+    # Use a ThreadPoolExecutor to run the synchronous function in a separate thread
+    with ThreadPoolExecutor() as pool:
+        return await loop.run_in_executor(pool, fetch_intro_message)
+
+
+__all__ = ['load_intro_message']

--- a/robusta_krr/utils/intro.py
+++ b/robusta_krr/utils/intro.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from .version import get_version
 
 
-ONLINE_LINK = 'https://api.robusta.dev/krr/intro'
+ONLINE_LINK = 'https://stg.api.robusta.dev/krr/intro'
 LOCAL_LINK = './intro.txt'
 TIMEOUT = 0.5
 

--- a/robusta_krr/utils/intro.py
+++ b/robusta_krr/utils/intro.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from .version import get_version
 
 
-ONLINE_LINK = 'https://stg.api.robusta.dev/krr/intro'
+ONLINE_LINK = 'https://api.robusta.dev/krr/intro'
 LOCAL_LINK = './intro.txt'
 TIMEOUT = 0.5
 

--- a/robusta_krr/utils/intro.py
+++ b/robusta_krr/utils/intro.py
@@ -2,6 +2,8 @@ import requests
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
+from .version import get_version
+
 
 ONLINE_LINK = 'https://api.robusta.dev/krr/intro'
 LOCAL_LINK = './intro.txt'
@@ -12,7 +14,7 @@ TIMEOUT = 0.5
 def fetch_intro_message() -> str:
     try:
         # Attempt to get the message from the URL
-        response = requests.get(ONLINE_LINK, timeout=TIMEOUT)
+        response = requests.get(ONLINE_LINK, params={"version": get_version()}, timeout=TIMEOUT)
         response.raise_for_status()  # Raises an error for bad responses
         result = response.json()
         return result['message']

--- a/robusta_krr/utils/intro.py
+++ b/robusta_krr/utils/intro.py
@@ -3,7 +3,7 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
 
-ONLINE_LINK = 'https://github.com/robusta-dev/krr/blob/main/intro.txt'
+ONLINE_LINK = 'https://api.robusta.dev/krr/intro'
 LOCAL_LINK = './intro.txt'
 TIMEOUT = 0.5
 
@@ -14,7 +14,8 @@ def fetch_intro_message() -> str:
         # Attempt to get the message from the URL
         response = requests.get(ONLINE_LINK, timeout=TIMEOUT)
         response.raise_for_status()  # Raises an error for bad responses
-        return response.text
+        result = response.json()
+        return result['message']
     except Exception as e1:
         # If there's any error, fallback to local file
         try:

--- a/robusta_krr/utils/intro.py
+++ b/robusta_krr/utils/intro.py
@@ -15,13 +15,18 @@ def fetch_intro_message() -> str:
         response = requests.get(ONLINE_LINK, timeout=TIMEOUT)
         response.raise_for_status()  # Raises an error for bad responses
         return response.text
-    except Exception:
+    except Exception as e1:
         # If there's any error, fallback to local file
         try:
             with open(LOCAL_LINK, 'r') as file:
                 return file.read()
-        except Exception as e:
-            raise Exception("Failed to load the intro message from both URL and local file.") from e
+        except Exception as e2:
+            return (
+                "[red]Failed to load the intro message.\n"
+                f"Both from the URL: {e1.__class__.__name__} {e1}\n"
+                f"and the local file: {e2.__class__.__name__} {e2}\n"
+                "But as that is not critical, KRR will continue to run without the intro message.[/red]"
+            )
 
 
 async def load_intro_message() -> str:

--- a/robusta_krr/utils/version.py
+++ b/robusta_krr/utils/version.py
@@ -1,5 +1,28 @@
 import robusta_krr
+import requests
+import asyncio
+from typing import Optional
+from concurrent.futures import ThreadPoolExecutor
 
 
 def get_version() -> str:
     return robusta_krr.__version__
+
+
+# Synchronous function to fetch the latest release version from GitHub API
+def fetch_latest_version() -> Optional[str]:
+    url = "https://api.github.com/repos/robusta-dev/krr/releases/latest"
+    try:
+        response = requests.get(url, timeout=0.5)  # 0.5 seconds timeout
+        response.raise_for_status()  # Raises an error for bad responses
+        data = response.json()
+        return data.get("tag_name")  # Returns the tag name of the latest release
+    except Exception:
+        return None
+
+
+async def load_latest_version() -> Optional[str]:
+    loop = asyncio.get_running_loop()
+    # Run the synchronous function in a separate thread
+    with ThreadPoolExecutor() as pool:
+        return await loop.run_in_executor(pool, fetch_latest_version)


### PR DESCRIPTION
- Try to load the KRR introduction message from ~~git repository~~ Relay API (https://github.com/robusta-dev/relay/pull/76). Fallback to the local message file in case of something failed.
Additionally, move the ASCII art to that message (As I felt like it belongs there)
- Write that a newer KR version is available in case it is

@aantn Please feel free to update intro message

NOTE: Currently it is hard to show the message after the output, as we are parsing the last part of the message in a playbook (also mirrord has it in the beginning, so...)