### PR TITLE
Add selectors to Prometheus discovery

### DIFF
--- a/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
+++ b/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
@@ -34,6 +34,7 @@ class PrometheusDiscovery(MetricsServiceDiscovery):
 
         return super().find_url(
             selectors=[
+                "app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server",
                 "app=kube-prometheus-stack-prometheus",
                 "app=prometheus,component=server",
                 "app=prometheus-server",


### PR DESCRIPTION
Adds labels to the promethues discovery selectors that follow the convention used by the prometheus-community chart.

https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/templates/_helpers.tpl#L20
https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/templates/_helpers.tpl#L43

These are also the official Kuberneres [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels).