### PR TITLE
Don't show HPA warning if user chooses to run w/ HPA

### DIFF
--- a/robusta_krr/core/abstract/strategies.py
+++ b/robusta_krr/core/abstract/strategies.py
@@ -111,24 +111,15 @@ class BaseStrategy(abc.ABC, Generic[_StrategySettings]):
         self.settings = settings
 
     def __str__(self) -> str:
-        return self._display_name.title()
-
-    @property
-    def _display_name(self) -> str:
-        return getattr(self, "display_name", self.__class__.__name__.lower().removeprefix("strategy"))
+        return self.display_name.title()
 
     @property
     def description(self) -> Optional[str]:
         """
         Generate a description for the strategy.
-        You can use the settings in the description by using the format syntax.
-        Also you can use Rich's markdown syntax to format the description.
+        You can use Rich's markdown syntax to format the description.
         """
-
-        if self.__doc__ is None:
-            return None
-
-        return f"[b]{self} Strategy[/b]\n\n" + dedent(self.__doc__.format_map(self.settings.dict())).strip()
+        raise NotImplementedError()
 
     # Abstract method that needs to be implemented by subclass.
     # This method is intended to calculate resource recommendation based on history data and kubernetes object data.

--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -293,7 +293,7 @@ class Runner:
 
         return Result(
             scans=scans,
-            description=self._strategy.description,
+            description=f"[b]{self._strategy.display_name.title()} Strategy[/b]\n\n{self._strategy.description}",
             strategy=StrategyData(
                 name=str(self._strategy).lower(),
                 settings=self._strategy.settings.dict(),


### PR DESCRIPTION
I tested this by comparing output of the following two commands on this branch vs master and verifying that there were no unexpected changes to the output format other than what I wanted:

```
python3.9 krr.py simple --allow_hpa
python3.9 krr.py simple -f yaml --allow_hpa
```