### PR TITLE
Better --help text in krr

### DIFF
--- a/robusta_krr/main.py
+++ b/robusta_krr/main.py
@@ -19,7 +19,7 @@ from robusta_krr.core.models.config import Config
 from robusta_krr.core.runner import Runner
 from robusta_krr.utils.version import get_version
 
-app = typer.Typer(pretty_exceptions_show_locals=False, pretty_exceptions_short=True, no_args_is_help=True)
+app = typer.Typer(pretty_exceptions_show_locals=False, pretty_exceptions_short=True, no_args_is_help=True, help="IMPORTANT: Run `krr simple --help` to see all cli flags!")
 
 # NOTE: Disable insecure request warnings, as it might be expected to use self-signed certificates inside the cluster
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)


### PR DESCRIPTION
# Motivation
Users often run `krr --help` to learn about KRR cli flags, but that command doesn't output most flags! Most of the flags are only shown for `krr simple --help`. This PR tells users where to look for the real cli flags.

# Alternatives
Ideally `krr --help` would show all cli flags, but I don't know how to do this with the library we use (typer) and I suspect it isn't possible. So while I would prefer doing that, this was the only solution I found.