### PR TITLE
queries with no label filters bug

### DIFF
--- a/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
+++ b/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
@@ -228,11 +228,14 @@ class PrometheusMetricsService(MetricsService):
 
     async def get_cluster_summary(self) -> Dict[str, Any]:
         cluster_label = self.get_prometheus_cluster_label()
+
+        # use this for queries with no labels. turn ', cluster="xxx"' to 'cluster="xxx"'
+        single_cluster_label = cluster_label.replace(",", "")
         memory_query = f"""
-            sum(max by (instance) (machine_memory_bytes{{ {cluster_label} }}))
+            sum(max by (instance) (machine_memory_bytes{{ {single_cluster_label} }}))
         """
         cpu_query = f"""
-            sum(max by (instance) (machine_cpu_cores{{ {cluster_label} }}))
+            sum(max by (instance) (machine_cpu_cores{{ {single_cluster_label} }}))
         """
         kube_system_requests_mem = f"""
             sum(max(kube_pod_container_resource_requests{{ namespace='kube-system', resource='memory' {cluster_label} }})  by (job, pod, container) )


### PR DESCRIPTION
bug fix - On queries with no labels, adding the cluster label with a comma prefix created an invalid query ( `machine_memory_bytes{, cluster="foo"}` ) that failed

Fixes #325 