### PR TITLE
fix: allow overriding mimir headers

### DIFF
--- a/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
+++ b/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
@@ -96,8 +96,8 @@ class PrometheusMetricsService(MetricsService):
 
         logger.info(f"Using {self.name()} at {self.url} for cluster {cluster or 'default'}")
 
-        headers = {k: v.get_secret_value() for k, v in settings.prometheus_other_headers.items()}
-        headers |= self.additional_headers
+        headers = self.additional_headers
+        headers |= {k: v.get_secret_value() for k, v in settings.prometheus_other_headers.items()}
 
         if self.auth_header:
             headers |= {"Authorization": self.auth_header}


### PR DESCRIPTION
When connecting to Mimir the `X-Scope-OrgID: anonymous` tenant header is automatically set. However, when using the `--prometheus-headers` flag to set a custom value for this it isn't propagated. This change ensures that headers set through the cli flags overwrite any `additional_headers` specified in the code.