### PR TITLE
feat : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ WORKDIR /app
 
 COPY ./requirements.txt requirements.txt
 
-RUN pip install --upgrade pip
+RUN pip install --no-cache-dir --upgrade pip
 # Install the project dependencies
 RUN python -m ensurepip --upgrade
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application code
 COPY . .

--- a/docker/aws.Dockerfile
+++ b/docker/aws.Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 COPY ./requirements.txt requirements.txt
 
 # Install the project dependencies
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Install curl and unzip for awscli 
 RUN apt-get -y update; apt-get -y install curl; apt-get -y install unzip


### PR DESCRIPTION
using the "--no-cache-dir" flag in pip install, make sure downloaded packages by pip don't cache on the system. This is a best practice that makes sure to fetch from a repo instead of using a local cached one. Further, in the case of Docker Containers, by restricting caching, we can reduce image size. In terms of stats, it depends upon the number of python packages multiplied by their respective size. e.g for heavy packages with a lot of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6