### PR TITLE
add html formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
     <a href="https://github.com/robusta-dev/krr/issues">Request Feature</a>
     ·
     <a href="#support">Support</a>
-    <br /> Like KRR? Please ⭐ this repository to show your support! 
+    <br /> Like KRR? Please ⭐ this repository to show your support!
   </p>
 </div>
 <!-- TABLE OF CONTENTS -->
@@ -119,7 +119,7 @@ Read more about [how KRR works](#how-krr-works)
 
 <!-- GETTING STARTED -->
 
-## Installation 
+## Installation
 
 ### Requirements
 
@@ -130,7 +130,7 @@ KRR requires Prometheus 2.26+, [kube-state-metrics](https://github.com/kubernete
 No setup is required if you use kube-prometheus-stack or <a href="https://docs.robusta.dev/master/configuration/alertmanager-integration/embedded-prometheus.html">Robusta's Embedded Prometheus</a>.
 
 If you have a different setup, make sure the following metrics exist:
-  
+
 - `container_cpu_usage_seconds_total`
 - `container_memory_working_set_bytes`
 - `kube_replicaset_owner`
@@ -179,7 +179,7 @@ You can install using brew (see above) on [WSL2](https://docs.brew.sh/Homebrew-o
 
 <details>
   <summary>Airgapped Installation (Offline Environments)</summary>
-  
+
 You can download pre-built binaries from <a href="https://github.com/robusta-dev/krr/releases">Releases</a> or use the prebuilt Docker container. For example, the container for version 1.8.3 is:
 
 ```
@@ -258,7 +258,7 @@ We highly recommend using the [free Robusta SaaS platform](https://platform.robu
 
 <details>
   <summary>Basic usage</summary>
-  
+
 ```sh
 krr simple
 ```
@@ -266,7 +266,7 @@ krr simple
 
 <details>
   <summary>Tweak the recommendation algorithm (strategy)</summary>
-  
+
 Most helpful flags:
 
 - `--cpu-min` Sets the minimum recommended cpu value in millicores
@@ -347,6 +347,7 @@ Currently KRR ships with a few formatters to represent the scan data:
 - `yaml`
 - `pprint` - data representation from python's pprint library
 - `csv` - export data to a csv file in the current directory
+- `html`
 
 To run a strategy with a selected formatter, add a `-f` flag. Usually this should be combined with `--fileoutput <filename>` to write clean output to file without logs:
 

--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -120,8 +120,8 @@ class Runner:
                 file_name = settings.slack_output
 
             with open(file_name, "w") as target_file:
-                # don't use rich when writing a csv to avoid line wrapping etc
-                if settings.format == "csv":
+                # don't use rich when writing a csv or html to avoid line wrapping etc
+                if settings.format == "csv" or settings.format == "html":
                     target_file.write(formatted)
                 else:
                     console = Console(file=target_file, width=settings.width)

--- a/robusta_krr/formatters/__init__.py
+++ b/robusta_krr/formatters/__init__.py
@@ -3,3 +3,4 @@ from .pprint import pprint
 from .table import table
 from .yaml import yaml
 from .csv import csv
+from .html import html

--- a/robusta_krr/formatters/html.py
+++ b/robusta_krr/formatters/html.py
@@ -1,0 +1,12 @@
+from rich.console import Console
+
+from robusta_krr.core.abstract import formatters
+from robusta_krr.core.models.result import Result
+from .table import table
+
+@formatters.register("html")
+def html(result: Result) -> str:
+    console = Console(record=True)
+    table_output = table(result)
+    console.print(table_output)
+    return console.export_html(inline_styles=True)


### PR DESCRIPTION
**Problem Statement**

Default option `table` provides pretty output in console using styles (colors, etc..) but when we save it into a file using `--fileoutput` styles will not be passed. If we share the output file to others via s3 or something, styles will be missed and looks plain. It would be nice to keep the styles when rendering from the file.

**Solution**

Default option `table` using `Rich` library and same library has function `export_html` to generate html from table output. It will keep the same styles used in default table formatter.
