### PR TITLE
feat: expose labels and annotations in the model

### DIFF
--- a/robusta_krr/core/integrations/kubernetes/__init__.py
+++ b/robusta_krr/core/integrations/kubernetes/__init__.py
@@ -201,6 +201,14 @@ class ClusterLoader:
         namespace = item.metadata.namespace
         kind = kind or item.__class__.__name__[2:]
 
+        labels = {}
+        annotations = {}
+        if item.metadata.labels:
+            labels = item.metadata.labels
+
+        if item.metadata.annotations:
+            annotations = item.metadata.annotations
+
         obj = K8sObjectData(
             cluster=self.cluster,
             namespace=namespace,
@@ -209,6 +217,8 @@ class ClusterLoader:
             container=container.name,
             allocations=ResourceAllocations.from_container(container),
             hpa=self.__hpa_list.get((namespace, kind, name)),
+            labels=labels,
+            annotations= annotations
         )
         obj._api_resource = item
         return obj

--- a/robusta_krr/core/models/objects.py
+++ b/robusta_krr/core/models/objects.py
@@ -46,6 +46,8 @@ class K8sObjectData(pd.BaseModel):
     kind: KindLiteral
     allocations: ResourceAllocations
     warnings: set[PodWarning] = set()
+    labels: Optional[dict[str, str]]
+    annotations: Optional[dict[str, str]]
 
     _api_resource = pd.PrivateAttr(None)
 
@@ -98,6 +100,8 @@ class K8sObjectData(pd.BaseModel):
                 namespace=self.namespace,
                 kind=self.kind,
                 allocations=self.allocations,
+                labels=self.labels,
+                annotations=self.annotations,
             )
             for batch in batched(self.pods, n)
         ]


### PR DESCRIPTION
We would like to use labels and annotations to configure the strategy to behave differently for some workloads. This will expose labels and annotations in `object_data.annotations`/ `object_data.labels` to be used in strategies.