### PR TITLE
fix Argo Rollout CR wrong annotation type

### DIFF
--- a/robusta_krr/core/integrations/kubernetes/__init__.py
+++ b/robusta_krr/core/integrations/kubernetes/__init__.py
@@ -207,7 +207,10 @@ class ClusterLoader:
             labels = item.metadata.labels
 
         if item.metadata.annotations:
-            annotations = item.metadata.annotations
+            if type(item.metadata.annotations) is ObjectLikeDict:
+                annotations = item.metadata.annotations.__dict__
+            else:
+                annotations = item.metadata.annotations
 
         obj = K8sObjectData(
             cluster=self.cluster,


### PR DESCRIPTION
For Argo Rollouts managed objects we are getting annotations with type  `ObjectLikeDict` and the further object creation `obj = K8sObjectData` is falling with error 

`validation error for K8sObjectData annotations value is not a valid dict (type=type_error.dict) `

So we need to call a __dict__ method for explicit type conversion