### PR TITLE
Fix error on labels parsing  for ArgoRollout objects

### DIFF
--- a/robusta_krr/core/integrations/kubernetes/__init__.py
+++ b/robusta_krr/core/integrations/kubernetes/__init__.py
@@ -204,7 +204,7 @@ class ClusterLoader:
         labels = {}
         annotations = {}
         if item.metadata.labels:
-            if type(item.metadata.annotations) is ObjectLikeDict:
+            if type(item.metadata.labels) is ObjectLikeDict:
                 labels = item.metadata.labels.__dict__
             else:
                 labels = item.metadata.labels

--- a/robusta_krr/core/integrations/kubernetes/__init__.py
+++ b/robusta_krr/core/integrations/kubernetes/__init__.py
@@ -204,7 +204,10 @@ class ClusterLoader:
         labels = {}
         annotations = {}
         if item.metadata.labels:
-            labels = item.metadata.labels
+            if type(item.metadata.annotations) is ObjectLikeDict:
+                labels = item.metadata.labels.__dict__
+            else:
+                labels = item.metadata.labels
 
         if item.metadata.annotations:
             if type(item.metadata.annotations) is ObjectLikeDict:


### PR DESCRIPTION
An Error occurs on Rollout when parsing the labels because the time of labels apparently sometimes is robusta_krr.utils.object_like_dict.ObjectLikeDict

`
File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__ 
pydantic.error_wrappers.ValidationError: 1 validation error for K8sObjectData
labels
value is not a valid dict (type=type_error.dict) 
`

This PR re-uses the fix that was applied on annotations and fixes the issue.