### PR TITLE
Use session token for AWS authentication

### DIFF
--- a/robusta_krr/core/integrations/prometheus/prometheus_utils.py
+++ b/robusta_krr/core/integrations/prometheus/prometheus_utils.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import boto3
-from prometrix import AWSPrometheusConfig, CoralogixPrometheusConfig, PrometheusConfig, VictoriaMetricsPrometheusConfig
+from prometrix import (
+    AWSPrometheusConfig,
+    CoralogixPrometheusConfig,
+    PrometheusConfig,
+    VictoriaMetricsPrometheusConfig,
+)
 
 from robusta_krr.core.models.config import settings
 
@@ -37,9 +42,26 @@ def generate_prometheus_config(
         session = boto3.Session(profile_name=settings.eks_managed_prom_profile_name)
         credentials = session.get_credentials()
         credentials = credentials.get_frozen_credentials()
-        region = settings.eks_managed_prom_region if settings.eks_managed_prom_region else session.region_name
-        access_key = settings.eks_access_key if settings.eks_access_key else credentials.access_key
-        secret_key = settings.eks_secret_key.get_secret_value() if settings.eks_secret_key else credentials.secret_key
+        region = (
+            settings.eks_managed_prom_region
+            if settings.eks_managed_prom_region
+            else session.region_name
+        )
+        access_key = (
+            settings.eks_access_key
+            if settings.eks_access_key
+            else credentials.access_key
+        )
+        secret_key = (
+            settings.eks_secret_key.get_secret_value()
+            if settings.eks_secret_key
+            else credentials.secret_key
+        )
+        token = (
+            settings.eks_token.get_secret_value()
+            if settings.eks_token
+            else credentials.token
+        )
         service_name = settings.eks_service_name if settings.eks_secret_key else "aps"
         if not region:
             raise Exception("No eks region specified")
@@ -47,13 +69,16 @@ def generate_prometheus_config(
         return AWSPrometheusConfig(
             access_key=access_key,
             secret_access_key=secret_key,
+            token=token,
             aws_region=region,
             service_name=service_name,
             **baseconfig,
         )
     # coralogix config
     if settings.coralogix_token:
-        return CoralogixPrometheusConfig(**baseconfig, prometheus_token=settings.coralogix_token.get_secret_value())
+        return CoralogixPrometheusConfig(
+            **baseconfig, prometheus_token=settings.coralogix_token.get_secret_value()
+        )
     if isinstance(metrics_service, VictoriaMetricsService):
         return VictoriaMetricsPrometheusConfig(**baseconfig)
     return PrometheusConfig(**baseconfig)

--- a/robusta_krr/core/models/config.py
+++ b/robusta_krr/core/models/config.py
@@ -44,6 +44,7 @@ class Config(pd.BaseSettings):
     eks_managed_prom_profile_name: Optional[str] = pd.Field(None)
     eks_access_key: Optional[str] = pd.Field(None)
     eks_secret_key: Optional[pd.SecretStr] = pd.Field(None)
+    eks_token: Optional[pd.SecretStr] = pd.Field(None)
     eks_service_name: Optional[str] = pd.Field(None)
     eks_managed_prom_region: Optional[str] = pd.Field(None)
     coralogix_token: Optional[pd.SecretStr] = pd.Field(None)
@@ -91,32 +92,46 @@ class Config(pd.BaseSettings):
         return v
 
     @pd.validator("prometheus_other_headers", pre=True)
-    def validate_prometheus_other_headers(cls, headers: Union[list[str], dict[str, str]]) -> dict[str, str]:
+    def validate_prometheus_other_headers(
+        cls, headers: Union[list[str], dict[str, str]]
+    ) -> dict[str, str]:
         if isinstance(headers, dict):
             return headers
 
-        return {k.strip().lower(): v.strip() for k, v in [header.split(":") for header in headers]}
+        return {
+            k.strip().lower(): v.strip()
+            for k, v in [header.split(":") for header in headers]
+        }
 
     @pd.validator("namespaces")
-    def validate_namespaces(cls, v: Union[list[str], Literal["*"]]) -> Union[list[str], Literal["*"]]:
+    def validate_namespaces(
+        cls, v: Union[list[str], Literal["*"]]
+    ) -> Union[list[str], Literal["*"]]:
         if v == []:
             return "*"
 
         if isinstance(v, list):
             for val in v:
                 if val.startswith("*"):
-                    raise ValueError("Namespace's values cannot start with an asterisk (*)")
+                    raise ValueError(
+                        "Namespace's values cannot start with an asterisk (*)"
+                    )
 
         return [val.lower() for val in v]
 
     @pd.validator("resources", pre=True)
-    def validate_resources(cls, v: Union[list[str], Literal["*"]]) -> Union[list[str], Literal["*"]]:
+    def validate_resources(
+        cls, v: Union[list[str], Literal["*"]]
+    ) -> Union[list[str], Literal["*"]]:
         if v == []:
             return "*"
 
         # NOTE: KindLiteral.__args__ is a tuple of all possible values of KindLiteral
         # So this will preserve the big and small letters of the resource
-        return [next(r for r in KindLiteral.__args__ if r.lower() == val.lower()) for val in v]
+        return [
+            next(r for r in KindLiteral.__args__ if r.lower() == val.lower())
+            for val in v
+        ]
 
     def create_strategy(self) -> AnyStrategy:
         StrategyType = AnyStrategy.find(self.strategy)
@@ -140,7 +155,9 @@ class Config(pd.BaseSettings):
     @property
     def logging_console(self) -> Console:
         if getattr(self, "_logging_console") is None:
-            self._logging_console = Console(file=sys.stderr if self.log_to_stderr else sys.stdout, width=self.width)
+            self._logging_console = Console(
+                file=sys.stderr if self.log_to_stderr else sys.stdout, width=self.width
+            )
         return self._logging_console
 
     def load_kubeconfig(self) -> None:
@@ -155,7 +172,9 @@ class Config(pd.BaseSettings):
         if context is None:
             return None
 
-        api_client = config.new_client_from_config(context=context, config_file=self.kubeconfig)
+        api_client = config.new_client_from_config(
+            context=context, config_file=self.kubeconfig
+        )
         if self.impersonate_user is not None:
             # trick copied from https://github.com/kubernetes-client/python/issues/362
             api_client.set_default_header("Impersonate-User", self.impersonate_user)
@@ -175,7 +194,13 @@ class Config(pd.BaseSettings):
             handlers=[RichHandler(console=config.logging_console)],
         )
         logging.getLogger("").setLevel(logging.CRITICAL)
-        logger.setLevel(logging.DEBUG if config.verbose else logging.CRITICAL if config.quiet else logging.INFO)
+        logger.setLevel(
+            logging.DEBUG
+            if config.verbose
+            else logging.CRITICAL
+            if config.quiet
+            else logging.INFO
+        )
 
     @staticmethod
     def get_config() -> Optional[Config]:

--- a/robusta_krr/main.py
+++ b/robusta_krr/main.py
@@ -171,6 +171,12 @@ def load_commands() -> None:
                     help="Sets the secret key for eks prometheus connection.",
                     rich_help_panel="Prometheus EKS Settings",
                 ),
+                eks_token: Optional[str] = typer.Option(
+                    None,
+                    "--eks-token",
+                    help="Sets the session token for eks prometheus connection.",
+                    rich_help_panel="Prometheus EKS Settings",
+                ),
                 eks_service_name: Optional[str] = typer.Option(
                     "aps",
                     "--eks-service-name",
@@ -234,13 +240,24 @@ def load_commands() -> None:
                     rich_help_panel="Output Settings",
                 ),
                 verbose: bool = typer.Option(
-                    False, "--verbose", "-v", help="Enable verbose mode", rich_help_panel="Logging Settings"
+                    False,
+                    "--verbose",
+                    "-v",
+                    help="Enable verbose mode",
+                    rich_help_panel="Logging Settings",
                 ),
                 quiet: bool = typer.Option(
-                    False, "--quiet", "-q", help="Enable quiet mode", rich_help_panel="Logging Settings"
+                    False,
+                    "--quiet",
+                    "-q",
+                    help="Enable quiet mode",
+                    rich_help_panel="Logging Settings",
                 ),
                 log_to_stderr: bool = typer.Option(
-                    False, "--logtostderr", help="Pass logs to stderr", rich_help_panel="Logging Settings"
+                    False,
+                    "--logtostderr",
+                    help="Pass logs to stderr",
+                    rich_help_panel="Logging Settings",
                 ),
                 width: Optional[int] = typer.Option(
                     None,
@@ -270,7 +287,10 @@ def load_commands() -> None:
             ) -> None:
                 f"""Run KRR using the `{_strategy_name}` strategy"""
                 if not show_severity and format != "csv":
-                    raise click.BadOptionUsage("--exclude-severity", "--exclude-severity works only with format=csv")
+                    raise click.BadOptionUsage(
+                        "--exclude-severity",
+                        "--exclude-severity works only with format=csv",
+                    )
 
                 try:
                     config = Config(
@@ -292,6 +312,7 @@ def load_commands() -> None:
                         eks_managed_prom_profile_name=eks_managed_prom_profile_name,
                         eks_access_key=eks_access_key,
                         eks_secret_key=eks_secret_key,
+                        eks_token=eks_token,
                         eks_service_name=eks_service_name,
                         coralogix_token=coralogix_token,
                         openshift=openshift,
@@ -329,7 +350,14 @@ def load_commands() -> None:
                         kind=inspect.Parameter.KEYWORD_ONLY,
                         default=OptionInfo(
                             default=field_meta.default,
-                            param_decls=list(set([f"--{field_name}", f"--{field_name.replace('_', '-')}"])),
+                            param_decls=list(
+                                set(
+                                    [
+                                        f"--{field_name}",
+                                        f"--{field_name.replace('_', '-')}",
+                                    ]
+                                )
+                            ),
                             help=f"{field_meta.field_info.description}",
                             rich_help_panel="Strategy Settings",
                         ),

--- a/tests/formatters/test_csv_formatter.py
+++ b/tests/formatters/test_csv_formatter.py
@@ -119,6 +119,7 @@ RESULT = """
         "eks_managed_prom_profile_name": null,
         "eks_access_key": null,
         "eks_secret_key": null,
+        "eks_token": null,
         "eks_service_name": "aps",
         "eks_managed_prom_region": null,
         "coralogix_token": null,
@@ -215,7 +216,9 @@ def _load_result(override_config: dict[str, Any]) -> Result:
         ),
     ],
 )
-def test_csv_headers(override_config: dict[str, Any], expected_headers: list[str]) -> None:
+def test_csv_headers(
+    override_config: dict[str, Any], expected_headers: list[str]
+) -> None:
     result = _load_result(override_config=override_config)
     output = csv_exporter(result)
     reader = csv.DictReader(io.StringIO(output))
@@ -235,7 +238,7 @@ def test_csv_headers(override_config: dict[str, Any], expected_headers: list[str
                 "Old Pods": "1",
                 "Type": "Deployment",
                 "Container": "mock-container-1",
-                'Severity': 'CRITICAL',
+                "Severity": "CRITICAL",
                 "CPU Diff": "-87m",
                 "CPU Requests": "(-43m) 50m -> 6m",
                 "CPU Limits": "2.0 -> ?",
@@ -271,7 +274,7 @@ def test_csv_headers(override_config: dict[str, Any], expected_headers: list[str
                 "Old Pods": "1",
                 "Type": "Deployment",
                 "Container": "mock-container-1",
-                'Severity': 'CRITICAL',
+                "Severity": "CRITICAL",
                 "CPU Diff": "-87m",
                 "CPU Requests": "(-43m) 50m -> 6m",
                 "CPU Limits": "2.0 -> ?",
@@ -282,7 +285,9 @@ def test_csv_headers(override_config: dict[str, Any], expected_headers: list[str
         ),
     ],
 )
-def test_csv_row_value(override_config: dict[str, Any], expected_first_row: list[str]) -> None:
+def test_csv_row_value(
+    override_config: dict[str, Any], expected_first_row: list[str]
+) -> None:
     result = _load_result(override_config=override_config)
     output = csv_exporter(result)
     reader = csv.DictReader(io.StringIO(output))


### PR DESCRIPTION
The new option allows to use session token. This is the must if SSO is used that has keyless authentication.

It is also compatible with workload identity (ie. on EC2 instance or for Service Account used in EKS).
