### PR TITLE
Fix bug with AWS Credentials

### DIFF
--- a/robusta_krr/core/integrations/prometheus/prometheus_utils.py
+++ b/robusta_krr/core/integrations/prometheus/prometheus_utils.py
@@ -36,10 +36,18 @@ def generate_prometheus_config(
     if settings.eks_managed_prom:
         session = boto3.Session(profile_name=settings.eks_managed_prom_profile_name)
         credentials = session.get_credentials()
-        credentials = credentials.get_frozen_credentials()
         region = settings.eks_managed_prom_region if settings.eks_managed_prom_region else session.region_name
-        access_key = settings.eks_access_key if settings.eks_access_key else credentials.access_key
-        secret_key = settings.eks_secret_key.get_secret_value() if settings.eks_secret_key else credentials.secret_key
+
+        if settings.eks_access_key and settings.eks_secret_key:
+            # when we have both access key and secret key, don't try to read credentials which can fail
+            access_key = settings.eks_access_key
+            secret_key = settings.eks_secret_key.get_secret_value()
+        else:
+            # we need at least one parameter from credentials, but we should use whatever we can from settings (this has higher precedence)
+            credentials = credentials.get_frozen_credentials()
+            access_key = settings.eks_access_key if settings.eks_access_key else credentials.access_key
+            secret_key = settings.eks_secret_key.get_secret_value() if settings.eks_secret_key else credentials.secret_key
+        
         service_name = settings.eks_service_name if settings.eks_secret_key else "aps"
         if not region:
             raise Exception("No eks region specified")


### PR DESCRIPTION
When the user overrides AWS credentials via CLI, don't try to fetch credentials via boto3 (this can fail and isn't necessary anyway)