### PR TITLE
make slack api safer and update to file_upload_v2

### DIFF
--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -163,7 +163,7 @@ class Runner:
                         os.remove(file_name)
 
                 except Exception as e:
-                    logger.info(f"Unexpected error: {e}")
+                    logger.exception(f"Unexpected error: {e}")
 
     def __get_resource_minimal(self, resource: ResourceType) -> float:
         if resource == ResourceType.CPU:


### PR DESCRIPTION
origonal file upload api is deprecated
due to limitations of file_upload_v2 the message` Kubernetes Resource Report for splunk` needs to be sent seperatly since it is used to get the internal channel ID name which file_upload_v2 requires

Looks identical - first is orig, second is new
![Screen Shot 2025-03-04 at 16 33 54](https://github.com/user-attachments/assets/f5ed2388-dcce-4e3c-ae54-cc00d3a29781)
