### PR TITLE
Check for rich formatting being enabled / disabled on a formatter

### DIFF
--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -121,7 +121,7 @@ class Runner:
 
             with open(file_name, "w") as target_file:
                 # don't use rich when writing a csv or html to avoid line wrapping etc
-                if settings.format == "csv" or settings.format == "html" or settings.format == "json" or settings.format == "yaml":
+                if not rich or settings.format in ["csv", "html", "json", "yaml"]:
                     target_file.write(formatted)
                 else:
                     console = Console(file=target_file, width=settings.width)


### PR DESCRIPTION
We have a use case for a custom CSV formatter, and when I use it, I am running into an issue with line-wrapping causing the CSV to not render correctly. So it seems like when I set `rich_console=False` when setting up a custom formatter, that should disable the `console.print` function. This fixes the issue I was having when writing the CSV.

This PR enables using the value of `rich_console` in a formatter's decorator to specify whether to write a file directly or using Console to print, and converts the `settings.format` conditional to a more Pythonic approach.