### PR TITLE
Update memory_query and cpu_query for Prometheus

### DIFF
--- a/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
+++ b/robusta_krr/core/integrations/prometheus/metrics_service/prometheus_metrics_service.py
@@ -237,11 +237,13 @@ class PrometheusMetricsService(MetricsService):
 
         # use this for queries with no labels. turn ', cluster="xxx"' to 'cluster="xxx"'
         single_cluster_label = cluster_label.replace(",", "")
+
         memory_query = f"""
-            sum(max by (instance) (machine_memory_bytes{{ {single_cluster_label} }}))
+            sum(kube_node_status_capacity{{ resource='memory' {single_cluster_label} }})
         """
+
         cpu_query = f"""
-            sum(max by (instance) (machine_cpu_cores{{ {single_cluster_label} }}))
+            sum(kube_node_status_capacity{{ resource='cpu' {single_cluster_label} }})
         """
         kube_system_requests_mem = f"""
             sum(max(kube_pod_container_resource_requests{{ namespace='kube-system', resource='memory' {cluster_label} }})  by (job, pod, container) )


### PR DESCRIPTION
machine_memory_bytes and machine_cpu_cores have been [deprecated] (https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/cluster/node-metrics.md) [as per StackOverflow] (https://stackoverflow.com/questions/63901926/how-to-query-the-total-memory-available-to-kubernetes-nodes)

This issue came up for me when querying Azure Managed Prometheus, as these queries no longer exist there. I've tested these queries on both manually deployed Prometheus as well as Azure Managed Prometheus and the query works and returns the same data. 