### PR TITLE
feat: add new csv-raw export format for calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Currently KRR ships with a few formatters to represent the scan data:
 - `yaml`
 - `pprint` - data representation from python's pprint library
 - `csv` - export data to a csv file in the current directory
+- `csv-raw` - csv with raw data for calculation
 - `html`
 
 To run a strategy with a selected formatter, add a `-f` flag. Usually this should be combined with `--fileoutput <filename>` to write clean output to file without logs:

--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -121,7 +121,7 @@ class Runner:
 
             with open(file_name, "w") as target_file:
                 # don't use rich when writing a csv or html to avoid line wrapping etc
-                if settings.format == "csv" or settings.format == "html" or settings.format == "json" or settings.format == "yaml":
+                if settings.format in ("csv", "csv-raw", "html", "json", "yaml"):
                     target_file.write(formatted)
                 else:
                     console = Console(file=target_file, width=settings.width)

--- a/robusta_krr/formatters/__init__.py
+++ b/robusta_krr/formatters/__init__.py
@@ -3,4 +3,5 @@ from .pprint import pprint
 from .table import table
 from .yaml import yaml
 from .csv import csv
+from .csv_raw import csv_raw
 from .html import html

--- a/robusta_krr/formatters/csv_raw.py
+++ b/robusta_krr/formatters/csv_raw.py
@@ -1,0 +1,110 @@
+import csv
+import io
+import logging
+from typing import Any, Union
+
+from robusta_krr.core.abstract import formatters
+from robusta_krr.core.models.allocations import NAN_LITERAL, NONE_LITERAL
+from robusta_krr.core.models.config import settings
+from robusta_krr.core.models.result import ResourceScan, ResourceType, Result
+
+logger = logging.getLogger("krr")
+
+
+NAMESPACE_HEADER = "Namespace"
+NAME_HEADER = "Name"
+PODS_HEADER = "Pods"
+OLD_PODS_HEADER = "Old Pods"
+TYPE_HEADER = "Type"
+CONTAINER_HEADER = "Container"
+CLUSTER_HEADER = "Cluster"
+SEVERITY_HEADER = "Severity"
+
+RESOURCE_REQUESTS_CURRENT_HEADER = "{resource_name} Requests Current"
+RESOURCE_REQUESTS_RECOMMENDED_HEADER = '{resource_name} Requests Recommended'
+
+RESOURCE_LIMITS_CURRENT_HEADER = "{resource_name} Limits Current"
+RESOURCE_LIMITS_RECOMMENDED_HEADER = '{resource_name} Limits Recommended'
+
+
+def _format_value(val: Union[float, int]) -> str:
+    if isinstance(val, int):
+        return str(val)
+    elif isinstance(val, float):
+        return str(int(val)) if val.is_integer() else str(val)
+    elif val is None:
+        return NONE_LITERAL
+    elif isinstance(val, str):
+        return NAN_LITERAL
+    else:
+        raise ValueError(f'unknown value: {val}')
+
+
+def _format_request_current(item: ResourceScan, resource: ResourceType, selector: str) -> str:
+    allocated = getattr(item.object.allocations, selector)[resource]
+    if allocated is None:
+        return NONE_LITERAL
+    return _format_value(allocated)
+
+
+def _format_request_recommend(item: ResourceScan, resource: ResourceType, selector: str) -> str:
+    recommended = getattr(item.recommended, selector)[resource]
+    if recommended is None:
+        return NONE_LITERAL
+    return _format_value(recommended.value)
+
+
+@formatters.register("csv-raw")
+def csv_raw(result: Result) -> str:
+    # We need to order the resource columns so that they are in the format of
+    # Namespace, Name, Pods, Old Pods, Type, Container,
+    # CPU Requests Current, CPU Requests Recommend, CPU Limits Current, CPU Limits Recommend,
+    # Memory Requests Current, Memory Requests Recommend, Memory Limits Current, Memory Limits Recommend,
+    csv_columns = ["Namespace", "Name", "Pods", "Old Pods", "Type", "Container"]
+
+    if settings.show_cluster_name:
+        csv_columns.insert(0, "Cluster")
+
+    if settings.show_severity:
+        csv_columns.append("Severity")
+
+    for resource in ResourceType:
+        csv_columns.append(RESOURCE_REQUESTS_CURRENT_HEADER.format(resource_name=resource.name))
+        csv_columns.append(RESOURCE_REQUESTS_RECOMMENDED_HEADER.format(resource_name=resource.name))
+        csv_columns.append(RESOURCE_LIMITS_CURRENT_HEADER.format(resource_name=resource.name))
+        csv_columns.append(RESOURCE_LIMITS_RECOMMENDED_HEADER.format(resource_name=resource.name))
+
+    output = io.StringIO()
+    csv_writer = csv.DictWriter(output, csv_columns, extrasaction="ignore")
+    csv_writer.writeheader()
+
+    for item in result.scans:
+        row: dict[str, Any] = {
+            NAMESPACE_HEADER: item.object.namespace,
+            NAME_HEADER: item.object.name,
+            PODS_HEADER: f"{item.object.current_pods_count}",
+            OLD_PODS_HEADER: f"{item.object.deleted_pods_count}",
+            TYPE_HEADER: item.object.kind,
+            CONTAINER_HEADER: item.object.container,
+            SEVERITY_HEADER: item.severity,
+            CLUSTER_HEADER: item.object.cluster,
+        }
+
+        for resource in ResourceType:
+            resource: ResourceType
+            row[RESOURCE_REQUESTS_CURRENT_HEADER.format(resource_name=resource.name)] = _format_request_current(
+                item, resource, "requests"
+            )
+            row[RESOURCE_REQUESTS_RECOMMENDED_HEADER.format(resource_name=resource.name)] = _format_request_recommend(
+                item, resource, "requests"
+            )
+            row[RESOURCE_LIMITS_CURRENT_HEADER.format(resource_name=resource.name)] = _format_request_current(
+                item, resource, "limits"
+            )
+            row[RESOURCE_LIMITS_RECOMMENDED_HEADER.format(resource_name=resource.name)] = _format_request_recommend(
+                item, resource, "limits"
+            )
+
+        csv_writer.writerow(row)
+
+    return output.getvalue()


### PR DESCRIPTION
I added a new export format to avoid breaking existing functionality. Please let me know if there's anything that needs improvement.

Close https://github.com/robusta-dev/krr/issues/293

<details><summary>Result example</summary>
<p>

```csv
Namespace,Name,Pods,Old Pods,Type,Container,Severity,CPU Requests Current,CPU Requests Recommended,CPU Limits Current,CPU Limits Recommended,Memory Requests Current,Memory Requests Recommended,Memory Limits Current,Memory Limits Recommended
prometheus,prometheus-stack-grafana,1,0,Deployment,grafana-sc-dashboard,WARNING,unset,0.01,unset,unset,unset,110100480,unset,110100480
prometheus,prometheus-stack-grafana,1,0,Deployment,grafana-sc-datasources,WARNING,unset,0.01,unset,unset,unset,113246208,unset,113246208
prometheus,prometheus-stack-grafana,1,0,Deployment,grafana,WARNING,unset,0.01,unset,unset,unset,106954752,unset,106954752
prometheus,prometheus-stack-kube-prom-operator,1,0,Deployment,kube-prometheus-stack,WARNING,unset,0.01,unset,unset,unset,104857600,unset,104857600
prometheus,prometheus-stack-kube-state-metrics,1,0,Deployment,kube-state-metrics,WARNING,unset,0.01,unset,unset,unset,104857600,unset,104857600
prometheus,alertmanager-prometheus-stack-kube-prom-alertmanager,1,0,StatefulSet,alertmanager,WARNING,unset,0.01,unset,unset,209715200,104857600,unset,104857600
prometheus,alertmanager-prometheus-stack-kube-prom-alertmanager,1,0,StatefulSet,config-reloader,WARNING,unset,0.01,unset,unset,unset,104857600,unset,104857600
prometheus,prometheus-prometheus-stack-kube-prom-prometheus,1,0,StatefulSet,prometheus,WARNING,unset,0.057,unset,unset,unset,834666496,unset,834666496
prometheus,prometheus-prometheus-stack-kube-prom-prometheus,1,0,StatefulSet,config-reloader,WARNING,unset,0.01,unset,unset,unset,104857600,unset,104857600
prometheus,prometheus-stack-prometheus-node-exporter,3,0,DaemonSet,node-exporter,WARNING,unset,0.01,unset,unset,unset,104857600,unset,104857600
```

</p>
</details> 