### PR TITLE
krr-enforcer: Support envFrom in helm values

### DIFF
--- a/helm/krr-enforcer/templates/enforcer.yaml
+++ b/helm/krr-enforcer/templates/enforcer.yaml
@@ -111,6 +111,10 @@ spec:
               memory: {{ .Values.resources.limits.memory }}
               {{- end }}
             {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+          {{- toYaml .Values.envFrom | nindent 12 }}
+          {{- end }}
           env:
             - name: ENFORCER_SSL_KEY_FILE
               value: "/etc/webhook/certs/tls.key"

--- a/helm/krr-enforcer/values.yaml
+++ b/helm/krr-enforcer/values.yaml
@@ -15,6 +15,7 @@ resources:
   limits:
     cpu: ~
 additionalEnvVars: []
+envFrom: []
 priorityClassName: ""
 tolerations: []
 annotations: {}


### PR DESCRIPTION
For the cases like:
```ENV var replacement ROBUSTA_UI_TOKEN  does not exist for param: {{ env.ROBUSTA_UI_TOKEN }}```
Robusta runner sources Token via secret and refers it through envFrom. In order to inforcer
re-use secret, this commit adds envFrom support.

For example:
```
envFrom:
  - secretRef: name: robusta-runner-secret optional: true
```