### PR TITLE
fix: update Dockerfile comments to reflect Python 3.12 usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use the official Python 3.9 slim image as the base image
+# Use the official Python 3.12 slim image as the base image
 FROM python:3.12-slim AS builder
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/enforcer/Dockerfile
+++ b/enforcer/Dockerfile
@@ -1,4 +1,4 @@
-# Use the official Python 3.9 slim image as the base image
+# Use the official Python 3.12 slim image as the base image
 FROM python:3.12-slim
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
**Title:** Fix Dockerfile comments to reflect actual Python version

**Description:**
This PR fixes outdated comments in Dockerfiles that still referenced Python 3.9 while the actual base images were already using Python 3.12.

**Changes:**
- Updated comment in main `Dockerfile` from "Python 3.9 slim" to "Python 3.12 slim"
- Updated comment in `enforcer/Dockerfile` from "Python 3.9 slim" to "Python 3.12 slim"

**Type:** Documentation fix
