### PR TITLE
Modify simple-limit strategy to be more intuitive - fixes #413

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,11 +441,21 @@ Get a free breakdown of KRR recommendations in the [Robusta SaaS](#free-krr-ui-o
 
 ### Algorithm
 
-By default, we use a _simple_ strategy to calculate resource recommendations. It is calculated as follows (_The exact numbers can be customized in CLI arguments_):
+KRR provides multiple strategies for calculating resource recommendations:
 
-- For CPU, we set a request at the 95th percentile with no limit. Meaning, in 95% of the cases, your CPU request will be sufficient. For the remaining 5%, we set no limit. This means your pod can burst and use any CPU available on the node - e.g. CPU that other pods requested but aren’t using right now.
+#### Simple Strategy (default)
+By default, we use the _simple_ strategy (`krr simple`). It is calculated as follows (_The exact numbers can be customized in CLI arguments_):
 
-- For memory, we take the maximum value over the past week and add a 15% buffer.
+- **CPU**: Request at the 95th percentile, **limit unset** (allows unlimited bursting)
+- **Memory**: Maximum value over the past week + 15% buffer (same for request and limit)
+
+#### Simple-Limit Strategy  
+The _simple-limit_ strategy (`krr simple_limit`) provides both CPU requests and limits:
+
+- **CPU**: Request and limit both set to configurable percentiles (default 95th percentile for both)
+- **Memory**: Maximum value over the past week + 15% buffer (same for request and limit)
+
+**Key difference**: The simple strategy leaves CPU limits unset to allow unlimited bursting, while simple-limit sets explicit CPU limits.
 
 ### Prometheus connection
 

--- a/robusta_krr/strategies/simple.py
+++ b/robusta_krr/strategies/simple.py
@@ -25,7 +25,7 @@ from robusta_krr.core.integrations.prometheus.metrics import (
 
 
 class SimpleStrategySettings(StrategySettings):
-    cpu_percentile: float = pd.Field(95, gt=0, le=100, description="The percentile to use for the CPU recommendation.")
+    cpu_percentile: float = pd.Field(95, gt=0, le=100, description="The percentile to use for the CPU request recommendation. CPU limits are always unset to allow unlimited bursting.")
     memory_buffer_percentage: float = pd.Field(
         15, gt=0, description="The percentage of added buffer to the peak memory usage for memory recommendation."
     )
@@ -92,10 +92,12 @@ class SimpleStrategy(BaseStrategy[SimpleStrategySettings]):
     @property
     def description(self):
         s = textwrap.dedent(f"""\
-            CPU request: {self.settings.cpu_percentile}% percentile, limit: unset
+            CPU request: {self.settings.cpu_percentile}% percentile, limit: unset (allows unlimited bursting)
             Memory request: max + {self.settings.memory_buffer_percentage}%, limit: max + {self.settings.memory_buffer_percentage}%
             History: {self.settings.history_duration} hours
             Step: {self.settings.timeframe_duration} minutes
+            
+            This is the default strategy. If you want to se CPU limits, use 'krr simple-limit' instead.
 
             All parameters can be customized. For example: `krr simple --cpu_percentile=90 --memory_buffer_percentage=15 --history_duration=24 --timeframe_duration=0.5`
             """)

--- a/robusta_krr/strategies/simple_limit.py
+++ b/robusta_krr/strategies/simple_limit.py
@@ -25,8 +25,8 @@ from robusta_krr.core.integrations.prometheus.metrics import (
 
 
 class SimpleLimitStrategySettings(StrategySettings):
-    cpu_request: float = pd.Field(66, gt=0, le=100, description="The percentile to use for the CPU request.")
-    cpu_limit: float = pd.Field(96, gt=0, le=100, description="The percentile to use for the CPU limit.")
+    cpu_request: float = pd.Field(95, gt=0, le=100, description="The percentile to use for the CPU request.")
+    cpu_limit: float = pd.Field(95, gt=0, le=100, description="The percentile to use for the CPU limit. Unlike 'simple' strategy, this strategy sets explicit CPU limits.")
     memory_buffer_percentage: float = pd.Field(
         15, gt=0, description="The percentage of added buffer to the peak memory usage for memory recommendation."
     )
@@ -97,6 +97,9 @@ class SimpleLimitStrategy(BaseStrategy[SimpleLimitStrategySettings]):
             Memory request: max + {self.settings.memory_buffer_percentage}%, limit: max + {self.settings.memory_buffer_percentage}%
             History: {self.settings.history_duration} hours
             Step: {self.settings.timeframe_duration} minutes
+            
+            Unlike the 'simple' strategy, this strategy sets explicit CPU limits instead of leaving them unset.
+            Use this when you want to prevent CPU bursting beyond the configured limit.
 
             All parameters can be customized. For example: `krr simple_limit --cpu_request=66 --cpu_limit=96 --memory_buffer_percentage=15 --history_duration=24 --timeframe_duration=0.5`
             """)


### PR DESCRIPTION
This is a breaking change for users of the simple-limit strategy (non-default strategy), but I believe its worth it, as it removes very confusing default behaviour. See #413