### PR TITLE
Add --slacktitle CLI option to be able to provide a custom title in the Slack message output

### DIFF
--- a/robusta_krr/core/models/config.py
+++ b/robusta_krr/core/models/config.py
@@ -70,6 +70,7 @@ class Config(pd.BaseSettings):
     file_output: Optional[str] = pd.Field(None)
     file_output_dynamic: bool = pd.Field(False)
     slack_output: Optional[str] = pd.Field(None)
+    slack_title: Optional[str] = pd.Field(None)
     azureblob_output: Optional[str] = pd.Field(None)
     teams_webhook: Optional[str] = pd.Field(None)
     azure_subscription_id: Optional[str] = pd.Field(None)

--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -158,7 +158,7 @@ class Runner:
                 
                 # Post message with file link to channel
                 channel = settings.slack_output if settings.slack_output.startswith('#') else f"#{settings.slack_output}"
-                slack_title = settings.slack_title if settings.slack_title else f'Kubernetes Resource Report for {(" ".join(settings.namespaces))}\n{file_permalink}'
+                slack_title = settings.slack_title if settings.slack_title else f'Kubernetes Resource Report for {(" ".join(settings.namespaces))}'
                 client.chat_postMessage(
                     channel=channel,
                     text=f'{slack_title}\n{file_permalink}'

--- a/robusta_krr/core/runner.py
+++ b/robusta_krr/core/runner.py
@@ -158,9 +158,10 @@ class Runner:
                 
                 # Post message with file link to channel
                 channel = settings.slack_output if settings.slack_output.startswith('#') else f"#{settings.slack_output}"
+                slack_title = settings.slack_title if settings.slack_title else f'Kubernetes Resource Report for {(" ".join(settings.namespaces))}\n{file_permalink}'
                 client.chat_postMessage(
                     channel=channel,
-                    text=f'Kubernetes Resource Report for {(" ".join(settings.namespaces))}\n{file_permalink}'
+                    text=f'{slack_title}\n{file_permalink}'
                 )
                 
                 os.remove(file_name)

--- a/robusta_krr/main.py
+++ b/robusta_krr/main.py
@@ -266,6 +266,12 @@ def load_commands() -> None:
                     help="Send to output to a slack channel, must have SLACK_BOT_TOKEN with permissions: chat:write, files:write, chat:write.public. Bot must be added to the channel.",
                     rich_help_panel="Output Settings",
                 ),
+                slack_title: Optional[str] = typer.Option(
+                    None,
+                    "--slacktitle",
+                    help="Title of the slack message. If not provided, will use the default 'Kubernetes Resource Report for <environment>'.",
+                    rich_help_panel="Output Settings",
+                ),
                 azureblob_output: Optional[str] = typer.Option(
                     None,
                     "--azurebloboutput",
@@ -355,6 +361,7 @@ def load_commands() -> None:
                         file_output=file_output,
                         file_output_dynamic=file_output_dynamic,
                         slack_output=slack_output,
+                        slack_title=slack_title,
                         azureblob_output=azureblob_output,
                         teams_webhook=teams_webhook,
                         azure_subscription_id=azure_subscription_id,


### PR DESCRIPTION
This PR adds the ability to provide a custom message in the slack output. This is useful for example if you want to include the environment name or something similar.