### PR TITLE
feat: read sensitive CLI flags from environment variables

### DIFF
--- a/robusta_krr/main.py
+++ b/robusta_krr/main.py
@@ -118,7 +118,8 @@ def load_commands() -> None:
                 prometheus_auth_header: Optional[str] = typer.Option(
                     None,
                     "--prometheus-auth-header",
-                    help="Prometheus authentication header.",
+                    envvar="PROMETHEUS_AUTH_HEADER",
+                    help="Prometheus authentication header. Can also be supplied via the PROMETHEUS_AUTH_HEADER environment variable.",
                     rich_help_panel="Prometheus Settings",
                 ),
                 prometheus_other_headers: Optional[List[str]] = typer.Option(
@@ -162,13 +163,15 @@ def load_commands() -> None:
                 eks_access_key: Optional[str] = typer.Option(
                     None,
                     "--eks-access-key",
-                    help="Sets the access key for eks prometheus connection.",
+                    envvar="EKS_ACCESS_KEY",
+                    help="Sets the access key for eks prometheus connection. Can also be supplied via the EKS_ACCESS_KEY environment variable.",
                     rich_help_panel="Prometheus EKS Settings",
                 ),
                 eks_secret_key: Optional[str] = typer.Option(
                     None,
                     "--eks-secret-key",
-                    help="Sets the secret key for eks prometheus connection.",
+                    envvar="EKS_SECRET_KEY",
+                    help="Sets the secret key for eks prometheus connection. Can also be supplied via the EKS_SECRET_KEY environment variable.",
                     rich_help_panel="Prometheus EKS Settings",
                 ),
                 eks_service_name: Optional[str] = typer.Option(
@@ -192,7 +195,8 @@ def load_commands() -> None:
                 coralogix_token: Optional[str] = typer.Option(
                     None,
                     "--coralogix-token",
-                    help="Adds the token needed to query Coralogix managed prometheus.",
+                    envvar="CORALOGIX_TOKEN",
+                    help="Adds the token needed to query Coralogix managed prometheus. Can also be supplied via the CORALOGIX_TOKEN environment variable.",
                     rich_help_panel="Prometheus Coralogix Settings",
                 ),
                 openshift: bool = typer.Option(
@@ -311,7 +315,8 @@ def load_commands() -> None:
                 teams_webhook: Optional[str] = typer.Option(
                     None,
                     "--teams-webhook",
-                    help="Microsoft Teams webhook URL to send notifications when files are uploaded to Azure Blob Storage",
+                    envvar="TEAMS_WEBHOOK",
+                    help="Microsoft Teams webhook URL to send notifications when files are uploaded to Azure Blob Storage. Can also be supplied via the TEAMS_WEBHOOK environment variable.",
                     rich_help_panel="Output Settings",
                 ),
                 azure_subscription_id: Optional[str] = typer.Option(


### PR DESCRIPTION
## Summary

Adds `envvar=` to the Typer options for five sensitive CLI flags so they can be supplied via environment variables instead of command-line args. CLI args still take precedence when both are set, so this is fully backward-compatible.

| Flag | New env var |
|---|---|
| `--prometheus-auth-header` | `PROMETHEUS_AUTH_HEADER` |
| `--eks-access-key` | `EKS_ACCESS_KEY` |
| `--eks-secret-key` | `EKS_SECRET_KEY` |
| `--coralogix-token` | `CORALOGIX_TOKEN` |
| `--teams-webhook` | `TEAMS_WEBHOOK` |

Help text for each flag is updated to note the env-var alternative. No behavior changes when the env vars are unset.

## Motivation

When running KRR as a scheduled Kubernetes job (CronJob, Argo CronWorkflow, etc.), tokens currently have to be passed on the command line — typically via shell expansion of env vars mounted from a Secret. This leaves the token visible to `ps` inside the container.

With `envvar=`, the same Secret can be mounted as env vars and KRR's Pydantic `BaseSettings` picks them up directly. Tokens never appear in argv.

This matches the pattern KRR already uses for `SLACK_BOT_TOKEN`, which is env-only.

## Why these five fields

These are the CLI flags whose values are credentials or signed URLs. Other flags (e.g. `--prometheus-url`, `--slackoutput`) are not sensitive and the existing CLI-only behavior is fine for them — though `envvar=` could be added to those too in a follow-up if useful.

## Backward compatibility

- No flag removed, renamed, or repurposed.
- CLI args still override env vars (Typer's default precedence).
- Existing deployments that pass these flags on the CLI continue to work unchanged.

## Example

Before:

```yaml
args:
  - sh
  - -c
  - 'python krr.py simple --coralogix-token "$CORALOGIX_TOKEN" --slackoutput "#infra-cost"'
env:
  - name: CORALOGIX_TOKEN
    valueFrom: { secretKeyRef: { name: krr, key: CORALOGIX_TOKEN } }
```

After:

```yaml
args: ["simple", "--slackoutput", "#infra-cost"]
env:
  - name: CORALOGIX_TOKEN
    valueFrom: { secretKeyRef: { name: krr, key: CORALOGIX_TOKEN } }
  - name: SLACK_BOT_TOKEN
    valueFrom: { secretKeyRef: { name: krr, key: SLACK_BOT_TOKEN } }
```

Happy to add tests or split into multiple commits/PRs if that fits your review preferences — let me know.