### PR TITLE
Patch urllib3 CVEs in enforcer: bump to 2.7.0

### DIFF
--- a/enforcer/requirements.txt
+++ b/enforcer/requirements.txt
@@ -7,4 +7,4 @@ cachetools==5.3.3
 prometheus-client==0.20.0
 kubernetes==26.1.0
 pyasn1>=0.6.2
-urllib3==2.6.3
+urllib3==2.7.0


### PR DESCRIPTION
## Summary

Follow-up to #527, which bumped urllib3 in the main krr image but left the **enforcer** image still pinned to the vulnerable `urllib3==2.6.3`.

Bumps `enforcer/requirements.txt` `2.6.3` → `2.7.0` to resolve both HIGH-severity findings on the `krr-enforcer` image:

- **CVE-2026-44431** (5.3): sensitive headers (Authorization/Cookie/Proxy-Authorization) forwarded on cross-origin redirects.
- **CVE-2026-44432** (7.5): DoS via excessive HTTP response decompression — CWE-409.

## Note

The `krr-enforcer` image is built/pushed manually (no CI workflow), so a new image build is required after merge for the fix to reach deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)