### PR TITLE
feat: add selector for victoriametrics running in cluster mode

### DIFF
--- a/robusta_krr/core/integrations/prometheus/metrics_service/victoria_metrics_service.py
+++ b/robusta_krr/core/integrations/prometheus/metrics_service/victoria_metrics_service.py
@@ -27,6 +27,7 @@ class VictoriaMetricsDiscovery(MetricsServiceDiscovery):
             url = super().find_url(
                 selectors=[
                     "app.kubernetes.io/name=vmselect",
+                    "app.kubernetes.io/component=vmselect",
                     "app=vmselect",
                 ]
             )


### PR DESCRIPTION
Add selector "app.kubernetes.io/component=vmselect" to find service victoria-metrics-cluster-vmselect deployed by https://artifacthub.io/packages/helm/victoriametrics/victoria-metrics-cluster