### PR TITLE
feat: implement burstable strategy for mem and cpu

### DIFF
--- a/robusta_krr/core/integrations/prometheus/metrics/__init__.py
+++ b/robusta_krr/core/integrations/prometheus/metrics/__init__.py
@@ -1,3 +1,3 @@
 from .base import PrometheusMetric
 from .cpu import CPUAmountLoader, CPULoader, PercentileCPULoader
-from .memory import MaxMemoryLoader, MemoryAmountLoader, MemoryLoader, MaxOOMKilledMemoryLoader
+from .memory import MaxMemoryLoader, MaxOOMKilledMemoryLoader, MemoryAmountLoader, MemoryLoader, PercentileMemoryLoader

--- a/robusta_krr/core/integrations/prometheus/metrics/memory.py
+++ b/robusta_krr/core/integrations/prometheus/metrics/memory.py
@@ -71,6 +71,36 @@ class MemoryAmountLoader(PrometheusMetric):
         """
 
 
+def PercentileMemoryLoader(percentile: float) -> type[PrometheusMetric]:
+    """
+    A factory for creating percentile memory usage metric loaders.
+    """
+
+    if not 0 <= percentile <= 100:
+        raise ValueError("percentile must be between 0 and 100")
+
+    class PercentileMemoryLoader(PrometheusMetric):
+        def get_query(self, object: K8sObjectData, duration: str, step: str) -> str:
+            pods_selector = "|".join(pod.name for pod in object.pods)
+            cluster_label = self.get_prometheus_cluster_label()
+            return f"""
+                quantile_over_time(
+                    {round(percentile / 100, 2)},
+                    max(
+                        container_memory_working_set_bytes{{
+                            namespace="{object.namespace}",
+                            pod=~"{pods_selector}",
+                            container="{object.container}"
+                            {cluster_label}
+                        }}
+                    ) by (container, pod, job)
+                    [{duration}:{step}]
+                )
+            """
+
+    return PercentileMemoryLoader
+
+
 # TODO: Need to battle test if this one is correct.
 class MaxOOMKilledMemoryLoader(PrometheusMetric):
     """

--- a/robusta_krr/strategies/__init__.py
+++ b/robusta_krr/strategies/__init__.py
@@ -1,2 +1,3 @@
+from .burstable import BurstableStrategy
 from .simple import SimpleStrategy
 from .simple_limit import SimpleLimitStrategy

--- a/robusta_krr/strategies/burstable.py
+++ b/robusta_krr/strategies/burstable.py
@@ -1,0 +1,191 @@
+import textwrap
+from datetime import timedelta
+
+import numpy as np
+import pydantic as pd
+
+from robusta_krr.core.abstract.strategies import (
+    BaseStrategy,
+    K8sObjectData,
+    MetricsPodData,
+    ResourceRecommendation,
+    ResourceType,
+    RunResult,
+    StrategySettings,
+)
+from robusta_krr.core.integrations.prometheus.metrics import (
+    CPUAmountLoader,
+    MaxOOMKilledMemoryLoader,
+    MemoryAmountLoader,
+    PercentileCPULoader,
+    PercentileMemoryLoader,
+    PrometheusMetric,
+)
+
+
+def _named_loader(factory_fn, name: str, percentile: float) -> type[PrometheusMetric]:
+    cls = factory_fn(percentile)
+    cls.__name__ = name
+    cls.__qualname__ = name
+    return cls
+
+
+class BurstableStrategySettings(StrategySettings):
+    cpu_requests_percentile: float = pd.Field(
+        50, gt=0, le=100, description="The percentile to use for the CPU request recommendation."
+    )
+    cpu_limits_percentile: float = pd.Field(
+        99, gt=0, le=100, description="The percentile to use for the CPU limit recommendation."
+    )
+    memory_requests_percentile: float = pd.Field(
+        50, gt=0, le=100, description="The percentile to use for the memory request recommendation."
+    )
+    memory_limits_percentile: float = pd.Field(
+        90, gt=0, le=100, description="The percentile to use for the memory limit recommendation."
+    )
+    memory_buffer_percentage: float = pd.Field(
+        15, gt=0, description="The percentage of added buffer on top of the memory limit percentile."
+    )
+    disable_cpu_limit: bool = pd.Field(
+        False, description="When set, CPU limit is left unset (Burstable QoS for CPU)."
+    )
+    points_required: int = pd.Field(
+        100, ge=1, description="The number of data points required to make a recommendation for a resource."
+    )
+    allow_hpa: bool = pd.Field(
+        False,
+        description="Whether to calculate recommendations even when there is an HPA scaler defined on that resource.",
+    )
+    use_oomkill_data: bool = pd.Field(
+        False,
+        description="Whether to bump the memory limit when OOMKills are detected (experimental).",
+    )
+    oom_memory_buffer_percentage: float = pd.Field(
+        25, ge=0, description="What percentage to increase the memory limit when there are OOMKill events."
+    )
+
+    def history_range_enough(self, history_range: tuple[timedelta, timedelta]) -> bool:
+        start, end = history_range
+        return (end - start) >= timedelta(hours=3)
+
+
+class BurstableStrategy(BaseStrategy[BurstableStrategySettings]):
+
+    display_name = "burstable"
+    rich_console = True
+
+    @property
+    def metrics(self) -> list[type[PrometheusMetric]]:
+        metrics = [
+            _named_loader(PercentileCPULoader,    "BurstableCPURequestLoader",    self.settings.cpu_requests_percentile),
+            _named_loader(PercentileCPULoader,    "BurstableCPULimitLoader",      self.settings.cpu_limits_percentile),
+            _named_loader(PercentileMemoryLoader, "BurstableMemoryRequestLoader", self.settings.memory_requests_percentile),
+            _named_loader(PercentileMemoryLoader, "BurstableMemoryLimitLoader",   self.settings.memory_limits_percentile),
+            CPUAmountLoader,
+            MemoryAmountLoader,
+        ]
+
+        if self.settings.use_oomkill_data:
+            metrics.append(MaxOOMKilledMemoryLoader)
+
+        return metrics
+
+    @property
+    def description(self):
+        cpu_limit_desc = "unset" if self.settings.disable_cpu_limit else f"{self.settings.cpu_limits_percentile}% percentile"
+        s = textwrap.dedent(f"""\
+            CPU request: {self.settings.cpu_requests_percentile}% percentile, limit: {cpu_limit_desc}
+            Memory request: {self.settings.memory_requests_percentile}% percentile, limit: {self.settings.memory_limits_percentile}% percentile + {self.settings.memory_buffer_percentage}% buffer
+            History: {self.settings.history_duration} hours
+            Step: {self.settings.timeframe_duration} minutes
+
+            All parameters can be customized. For example: `krr burstable --cpu-requests-percentile=50 --cpu-limits-percentile=99 --memory-requests-percentile=50 --memory-limits-percentile=90 --memory-buffer-percentage=15`
+            """)
+
+        if not self.settings.allow_hpa:
+            s += "\n" + textwrap.dedent("""\
+                This strategy does not work with objects with HPA defined (Horizontal Pod Autoscaler).
+                If HPA is defined for CPU or Memory, the strategy will return "?" for that resource.
+                You can override this behaviour by passing the --allow-hpa flag
+                """)
+
+        s += "\nLearn more: [underline]https://github.com/robusta-dev/krr#algorithm[/underline]"
+        return s
+
+    def __calculate_cpu_proposal(
+        self, history_data: MetricsPodData, object_data: K8sObjectData
+    ) -> ResourceRecommendation:
+        data_req = history_data["BurstableCPURequestLoader"]
+
+        if len(data_req) == 0:
+            return ResourceRecommendation.undefined(info="No data")
+
+        data_count = {pod: values[0, 1] for pod, values in history_data["CPUAmountLoader"].items()}
+        total_points_count = sum(data_count.values())
+
+        if total_points_count < self.settings.points_required:
+            return ResourceRecommendation.undefined(info="Not enough data")
+
+        if (
+            object_data.hpa is not None
+            and object_data.hpa.target_cpu_utilization_percentage is not None
+            and not self.settings.allow_hpa
+        ):
+            return ResourceRecommendation.undefined(info="HPA detected")
+
+        cpu_request = np.max([v[0, 1] for v in data_req.values()])
+        cpu_limit = (
+            None
+            if self.settings.disable_cpu_limit
+            else np.max([v[0, 1] for v in history_data["BurstableCPULimitLoader"].values()])
+        )
+        return ResourceRecommendation(request=cpu_request, limit=cpu_limit)
+
+    def __calculate_memory_proposal(
+        self, history_data: MetricsPodData, object_data: K8sObjectData
+    ) -> ResourceRecommendation:
+        data_req = history_data["BurstableMemoryRequestLoader"]
+
+        oomkill_detected = False
+
+        if self.settings.use_oomkill_data:
+            max_oomkill_data = history_data["MaxOOMKilledMemoryLoader"]
+            max_oomkill_value = (
+                np.max([values[0, 1] for values in max_oomkill_data.values()]) if len(max_oomkill_data) > 0 else 0
+            )
+            if max_oomkill_value != 0:
+                oomkill_detected = True
+        else:
+            max_oomkill_value = 0
+
+        if len(data_req) == 0:
+            return ResourceRecommendation.undefined(info="No data")
+
+        data_count = {pod: values[0, 1] for pod, values in history_data["MemoryAmountLoader"].items()}
+        total_points_count = sum(data_count.values())
+
+        if total_points_count < self.settings.points_required:
+            return ResourceRecommendation.undefined(info="Not enough data")
+
+        if (
+            object_data.hpa is not None
+            and object_data.hpa.target_memory_utilization_percentage is not None
+            and not self.settings.allow_hpa
+        ):
+            return ResourceRecommendation.undefined(info="HPA detected")
+
+        memory_request = np.max([v[0, 1] for v in data_req.values()])
+        memory_limit_base = np.max([v[0, 1] for v in history_data["BurstableMemoryLimitLoader"].values()])
+        memory_limit = max(
+            memory_limit_base * (1 + self.settings.memory_buffer_percentage / 100),
+            max_oomkill_value * (1 + self.settings.oom_memory_buffer_percentage / 100),
+        )
+        return ResourceRecommendation(
+            request=memory_request, limit=memory_limit, info="OOMKill detected" if oomkill_detected else None
+        )
+
+    def run(self, history_data: MetricsPodData, object_data: K8sObjectData) -> RunResult:
+        return {
+            ResourceType.CPU: self.__calculate_cpu_proposal(history_data, object_data),
+            ResourceType.Memory: self.__calculate_memory_proposal(history_data, object_data),
+        }

--- a/tests/test_burstable.py
+++ b/tests/test_burstable.py
@@ -1,0 +1,226 @@
+import math
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock
+from typer.testing import CliRunner
+
+from robusta_krr.main import app, load_commands
+from robusta_krr.core.abstract.strategies import ResourceType
+from robusta_krr.strategies.burstable import BurstableStrategy, BurstableStrategySettings
+
+runner = CliRunner(mix_stderr=False)
+load_commands()
+
+# Pre-computed percentile values — these are what Prometheus returns after
+# computing quantile_over_time on the server side.
+CPU_REQUEST_VALUE = 0.3    # p50 CPU (cores)
+CPU_LIMIT_VALUE   = 0.9    # p99 CPU (cores)
+MEM_REQUEST_VALUE = 300e6  # p50 memory (bytes)
+MEM_LIMIT_VALUE   = 800e6  # p90 memory (bytes)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_instant_data(value: float) -> dict:
+    """Single-row instant-query result per pod: [[timestamp, value]]."""
+    return {"pod-0": np.array([[0.0, float(value)]])}
+
+
+def make_count_data(count: int) -> dict:
+    return {"pod-0": np.array([[0.0, float(count)]])}
+
+
+def make_history_data(
+    cpu_request=CPU_REQUEST_VALUE,
+    cpu_limit=CPU_LIMIT_VALUE,
+    mem_request=MEM_REQUEST_VALUE,
+    mem_limit=MEM_LIMIT_VALUE,
+    count=200,
+    oom_value=0,
+):
+    data = {
+        "BurstableCPURequestLoader":    make_instant_data(cpu_request),
+        "BurstableCPULimitLoader":      make_instant_data(cpu_limit),
+        "BurstableMemoryRequestLoader": make_instant_data(mem_request),
+        "BurstableMemoryLimitLoader":   make_instant_data(mem_limit),
+        "CPUAmountLoader":              make_count_data(count),
+        "MemoryAmountLoader":           make_count_data(count),
+    }
+    if oom_value > 0:
+        data["MaxOOMKilledMemoryLoader"] = make_instant_data(oom_value)
+    return data
+
+
+def make_object_data(hpa=None):
+    obj = MagicMock()
+    obj.hpa = hpa
+    return obj
+
+
+def make_strategy(**kwargs):
+    return BurstableStrategy(BurstableStrategySettings(**kwargs))
+
+
+# ---------------------------------------------------------------------------
+# CPU recommendation tests
+# ---------------------------------------------------------------------------
+
+def test_cpu_request_and_limit_use_separate_values():
+    strategy = make_strategy()
+    result = strategy.run(make_history_data(cpu_request=0.3, cpu_limit=0.9), make_object_data())
+
+    cpu = result[ResourceType.CPU]
+    assert cpu.request == pytest.approx(0.3)
+    assert cpu.limit == pytest.approx(0.9)
+
+
+def test_cpu_limit_is_none_when_disabled():
+    strategy = make_strategy(disable_cpu_limit=True)
+    result = strategy.run(make_history_data(), make_object_data())
+
+    assert result[ResourceType.CPU].limit is None
+
+
+def test_cpu_no_data_returns_undefined():
+    strategy = make_strategy()
+    history = make_history_data()
+    history["BurstableCPURequestLoader"] = {}
+
+    result = strategy.run(history, make_object_data())
+    assert math.isnan(result[ResourceType.CPU].request)
+
+
+def test_cpu_not_enough_data_returns_undefined():
+    strategy = make_strategy(points_required=100)
+    result = strategy.run(make_history_data(count=10), make_object_data())
+
+    assert math.isnan(result[ResourceType.CPU].request)
+
+
+def test_cpu_hpa_returns_undefined_by_default():
+    hpa = MagicMock()
+    hpa.target_cpu_utilization_percentage = 80
+    strategy = make_strategy(allow_hpa=False)
+    result = strategy.run(make_history_data(), make_object_data(hpa=hpa))
+
+    assert math.isnan(result[ResourceType.CPU].request)
+
+
+def test_cpu_hpa_allowed_when_flag_set():
+    hpa = MagicMock()
+    hpa.target_cpu_utilization_percentage = 80
+    strategy = make_strategy(allow_hpa=True)
+    result = strategy.run(make_history_data(), make_object_data(hpa=hpa))
+
+    assert not math.isnan(result[ResourceType.CPU].request)
+
+
+# ---------------------------------------------------------------------------
+# Memory recommendation tests
+# ---------------------------------------------------------------------------
+
+def test_memory_request_has_no_buffer():
+    strategy = make_strategy(memory_buffer_percentage=15)
+    result = strategy.run(make_history_data(mem_request=300e6), make_object_data())
+
+    assert result[ResourceType.Memory].request == pytest.approx(300e6)
+
+
+def test_memory_limit_applies_buffer():
+    strategy = make_strategy(memory_buffer_percentage=15)
+    result = strategy.run(make_history_data(mem_limit=800e6), make_object_data())
+
+    assert result[ResourceType.Memory].limit == pytest.approx(800e6 * 1.15)
+
+
+def test_memory_limit_higher_than_request():
+    strategy = make_strategy(memory_buffer_percentage=15)
+    result = strategy.run(make_history_data(mem_request=300e6, mem_limit=800e6), make_object_data())
+
+    mem = result[ResourceType.Memory]
+    assert mem.limit > mem.request
+
+
+def test_oom_kill_bumps_limit_not_request():
+    oom_value = 3000e6  # larger than mem_limit * buffer → drives the limit
+    strategy = make_strategy(
+        use_oomkill_data=True,
+        oom_memory_buffer_percentage=25,
+        memory_buffer_percentage=15,
+    )
+    history = make_history_data(mem_request=300e6, mem_limit=800e6, oom_value=oom_value)
+    result = strategy.run(history, make_object_data())
+
+    mem = result[ResourceType.Memory]
+    assert mem.request == pytest.approx(300e6)
+    assert mem.limit == pytest.approx(oom_value * 1.25)
+
+
+def test_oom_kill_not_used_when_smaller_than_normal_limit():
+    oom_value = 1.0  # negligibly small → normal limit wins
+    strategy = make_strategy(
+        use_oomkill_data=True,
+        oom_memory_buffer_percentage=25,
+        memory_buffer_percentage=15,
+    )
+    history = make_history_data(mem_limit=800e6, oom_value=oom_value)
+    result = strategy.run(history, make_object_data())
+
+    assert result[ResourceType.Memory].limit == pytest.approx(800e6 * 1.15)
+
+
+def test_memory_no_data_returns_undefined():
+    strategy = make_strategy()
+    history = make_history_data()
+    history["BurstableMemoryRequestLoader"] = {}
+
+    result = strategy.run(history, make_object_data())
+    assert math.isnan(result[ResourceType.Memory].request)
+
+
+def test_memory_not_enough_data_returns_undefined():
+    strategy = make_strategy(points_required=100)
+    result = strategy.run(make_history_data(count=10), make_object_data())
+
+    assert math.isnan(result[ResourceType.Memory].request)
+
+
+def test_memory_hpa_returns_undefined_by_default():
+    hpa = MagicMock()
+    hpa.target_cpu_utilization_percentage = None
+    hpa.target_memory_utilization_percentage = 80
+    strategy = make_strategy(allow_hpa=False)
+    result = strategy.run(make_history_data(), make_object_data(hpa=hpa))
+
+    assert math.isnan(result[ResourceType.Memory].request)
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests
+# ---------------------------------------------------------------------------
+
+def test_burstable_help():
+    result = runner.invoke(app, ["burstable", "--help"])
+    try:
+        assert result.exit_code == 0
+    except AssertionError as e:
+        raise e from result.exception
+
+
+def test_burstable_settings_exposes_all_expected_fields():
+    expected = {
+        "cpu_requests_percentile",
+        "cpu_limits_percentile",
+        "memory_requests_percentile",
+        "memory_limits_percentile",
+        "memory_buffer_percentage",
+        "disable_cpu_limit",
+        "points_required",
+        "allow_hpa",
+        "use_oomkill_data",
+        "oom_memory_buffer_percentage",
+    }
+    assert expected.issubset(set(BurstableStrategySettings.__fields__.keys()))


### PR DESCRIPTION
The purpose of this PR is to add a basic "burstable" recommendation strategy.

As far as I can tell, the current strategies enforce a QoS recommendation (limit == request) for memory, while allowing CPU to be burstable.

While this makes sense in certain scenarios, I'm also running KRR in my homelab to propose resource adjustments. In such cases, apps are most of the time idling, with occasional usage spikes. Setting requests and limits to the same value as to accommodate that spike would result In massive over provisioning in this situation.

Hence I'm working on getting this strategy going that can recommend individual values for requests and limits based on percentiles, just like CPU recommendations work in the other strategies.

For reference, I'm running my fork of KRR (the code in this PR) like so: https://github.com/mirceanton/home-ops/tree/main/apps%2Fjobs%2Fkrr%2Fapp

To generate this "dashboard": https://github.com/mirceanton/home-ops/issues/559