### PR TITLE
Fix CI workflow deprecations and streamline build process

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-ubuntu:
     runs-on: ubuntu-latest
+    outputs:
+      LINUX_BUILD_HASH: ${{ steps.calc-hash.outputs.LINUX_BUILD_HASH }}
 
     steps:
     - uses: actions/checkout@v2
@@ -61,6 +63,10 @@ jobs:
       with:
         name: krr-ubuntu-latest-${{ github.ref_name }}
         path: ./krr-ubuntu-latest-${{ github.ref_name }}.zip
+
+    - name: Calculate hash
+      id: calc-hash
+      run: echo "LINUX_BUILD_HASH=$(sha256sum krr-ubuntu-latest-${{ github.ref_name }}.zip | awk '{print $1}')" >> $GITHUB_OUTPUT
 
   build-windows:
     runs-on: windows-latest
@@ -122,6 +128,8 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
+    outputs:
+      MAC_BUILD_HASH: ${{ steps.calc-hash.outputs.MAC_BUILD_HASH }}
 
     steps:
     - uses: actions/checkout@v2
@@ -201,6 +209,10 @@ jobs:
       with:
         name: krr-macos-latest-${{ github.ref_name }}
         path: ./krr-macos-latest-${{ github.ref_name }}.zip
+
+    - name: Calculate hash
+      id: calc-hash
+      run: echo "MAC_BUILD_HASH=$(shasum -a 256 krr-macos-latest-${{ github.ref_name }}.zip | awk '{print $1}')" >> $GITHUB_OUTPUT
 
     - name: Clean up keychain and provisioning profile
       if: always()
@@ -309,46 +321,11 @@ jobs:
           repository: ${{ github.repository }}
           excludes: prerelease, draft
 
-  # Define MacOS hash job
-  mac-hash:
-    needs: check-latest
-    runs-on: ubuntu-latest
-    if: needs.check-latest.outputs.IS_LATEST
-    outputs:
-      MAC_BUILD_HASH: ${{ steps.calc-hash.outputs.MAC_BUILD_HASH }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Download MacOS artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: krr-macos-latest-${{ github.ref_name }}
-      - name: Calculate hash
-        id: calc-hash
-        run: echo "MAC_BUILD_HASH=$(sha256sum krr-macos-latest-${{ github.ref_name }}.zip | awk '{print $1}')" >> $GITHUB_OUTPUT
-
-  # Define Linux hash job
-  linux-hash:
-    needs: check-latest
-    runs-on: ubuntu-latest
-    if: needs.check-latest.outputs.IS_LATEST
-    outputs:
-      LINUX_BUILD_HASH: ${{ steps.calc-hash.outputs.LINUX_BUILD_HASH }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Download Linux artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: krr-ubuntu-latest-${{ github.ref_name }}
-      - name: Calculate hash
-        id: calc-hash
-        run: echo "LINUX_BUILD_HASH=$(sha256sum krr-ubuntu-latest-${{ github.ref_name }}.zip | awk '{print $1}')" >> $GITHUB_OUTPUT
-
   # Define job to update homebrew formula
   update-formula:
-    needs: [mac-hash, linux-hash]
+    needs: [check-latest, build-macos, build-ubuntu]
     runs-on: ubuntu-latest
+    if: needs.check-latest.outputs.IS_LATEST
     steps:
       - name: Checkout homebrew-krr repository
         uses: actions/checkout@v2
@@ -357,8 +334,8 @@ jobs:
           token: ${{ secrets.MULTIREPO_GITHUB_TOKEN }}
       - name: Update krr.rb formula
         run: |
-          MAC_BUILD_HASH=${{ needs.mac-hash.outputs.MAC_BUILD_HASH }}
-          LINUX_BUILD_HASH=${{ needs.linux-hash.outputs.LINUX_BUILD_HASH }}
+          MAC_BUILD_HASH=${{ needs.build-macos.outputs.MAC_BUILD_HASH }}
+          LINUX_BUILD_HASH=${{ needs.build-ubuntu.outputs.LINUX_BUILD_HASH }}
           TAG_NAME=${{ github.ref_name }}
           awk 'NR==6{$0="        url \"https://github.com/robusta-dev/krr/releases/download/'"$TAG_NAME"'/krr-macos-latest-'"$TAG_NAME"'.zip\""}1' ./Formula/krr.rb > temp && mv temp ./Formula/krr.rb
           awk 'NR==7{$0="        sha256 \"'$MAC_BUILD_HASH'\""}1' ./Formula/krr.rb > temp && mv temp ./Formula/krr.rb

--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -5,13 +5,8 @@ on:
     types: [created]
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        # we build on macos-15-intel for x86 builds
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
-
-    runs-on: ${{ matrix.os }}
+  build-ubuntu:
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -20,7 +15,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.11'
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -28,12 +23,121 @@ jobs:
         pip install pyinstaller
 
     - name: Install dependancies (Linux)
-      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get install -y binutils
 
+    - name: Set version in code
+      run: |
+        awk 'NR==3{$0="__version__ = \"'${{ github.ref_name }}'\""}1' ./robusta_krr/__init__.py > temp && mv temp ./robusta_krr/__init__.py
+        cat ./robusta_krr/__init__.py
+
+    - name: Build with PyInstaller
+      shell: bash
+      run: |
+        pyinstaller krr.py
+        mkdir -p ./dist/krr/grapheme/data
+        cp $(python -c "import grapheme; print(grapheme.__path__[0] + '/data/grapheme_break_property.json')") ./dist/krr/grapheme/data/grapheme_break_property.json
+        cp ./intro.txt ./dist/krr/intro.txt
+
+    - name: Zip the application
+      run: |
+        cd dist
+        zip -r krr-ubuntu-latest-${{ github.ref_name }}.zip krr
+        mv krr-ubuntu-latest-${{ github.ref_name }}.zip ../
+        cd ..
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./krr-ubuntu-latest-${{ github.ref_name }}.zip
+        asset_name: krr-ubuntu-latest-${{ github.ref_name }}.zip
+        asset_content_type: application/octet-stream
+
+    - name: Upload build as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: krr-ubuntu-latest-${{ github.ref_name }}
+        path: ./krr-ubuntu-latest-${{ github.ref_name }}.zip
+
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pyinstaller
+
+    - name: Set version in code
+      run: |
+        $content = Get-Content -Path .\robusta_krr\__init__.py
+        $content[2] = "__version__=`"$($env:GITHUB_REF_NAME)`""
+        $content | Out-File -FilePath .\robusta_krr\__init__.py -Encoding ascii
+        Get-Content .\robusta_krr\__init__.py
+      shell: pwsh
+      env:
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+
+    - name: Build with PyInstaller
+      shell: bash
+      run: |
+        pyinstaller krr.py
+        mkdir -p ./dist/krr/grapheme/data
+        cp $(python -c "import grapheme; print(grapheme.__path__[0] + '/data/grapheme_break_property.json')") ./dist/krr/grapheme/data/grapheme_break_property.json
+        cp ./intro.txt ./dist/krr/intro.txt
+
+    - name: Zip the application
+      run: |
+        Set-Location -Path dist
+        Compress-Archive -Path krr -DestinationPath krr-windows-latest-${{ github.ref_name }}.zip -Force
+        Move-Item -Path krr-windows-latest-${{ github.ref_name }}.zip -Destination ..\
+        Set-Location -Path ..
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./krr-windows-latest-${{ github.ref_name }}.zip
+        asset_name: krr-windows-latest-${{ github.ref_name }}.zip
+        asset_content_type: application/octet-stream
+
+    - name: Upload build as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: krr-windows-latest-${{ github.ref_name }}
+        path: ./krr-windows-latest-${{ github.ref_name }}.zip
+
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pyinstaller
+
     - name: Install the Apple certificate and provisioning profile
-      if: matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel' 
       env:
         BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
         P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
@@ -62,25 +166,12 @@ jobs:
         mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
         cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
-    - name: Set version in code (Unix)
-      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15-intel' 
+    - name: Set version in code
       run: |
         awk 'NR==3{$0="__version__ = \"'${{ github.ref_name }}'\""}1' ./robusta_krr/__init__.py > temp && mv temp ./robusta_krr/__init__.py
         cat ./robusta_krr/__init__.py
 
-    - name: Set version in code (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        $content = Get-Content -Path .\robusta_krr\__init__.py
-        $content[2] = "__version__=`"$($env:GITHUB_REF_NAME)`""
-        $content | Out-File -FilePath .\robusta_krr\__init__.py -Encoding ascii
-        Get-Content .\robusta_krr\__init__.py
-      shell: pwsh
-      env:
-        GITHUB_REF_NAME: ${{ github.ref_name }}
-
     - name: Build with PyInstaller
-      if: matrix.os == 'macos-latest' 
       shell: bash
       run: |
         pyinstaller --target-architecture arm64 krr.py
@@ -88,8 +179,87 @@ jobs:
         cp $(python -c "import grapheme; print(grapheme.__path__[0] + '/data/grapheme_break_property.json')") ./dist/krr/grapheme/data/grapheme_break_property.json
         cp ./intro.txt ./dist/krr/intro.txt
 
+    - name: Zip the application
+      run: |
+        cd dist
+        zip -r krr-macos-latest-${{ github.ref_name }}.zip krr
+        mv krr-macos-latest-${{ github.ref_name }}.zip ../
+        cd ..
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./krr-macos-latest-${{ github.ref_name }}.zip
+        asset_name: krr-macos-latest-${{ github.ref_name }}.zip
+        asset_content_type: application/octet-stream
+
+    - name: Upload build as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: krr-macos-latest-${{ github.ref_name }}
+        path: ./krr-macos-latest-${{ github.ref_name }}.zip
+
+    - name: Clean up keychain and provisioning profile
+      if: always()
+      run: |
+        security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
+        rm ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision
+
+  build-macos-intel:
+    runs-on: macos-15-intel
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pyinstaller
+
+    - name: Install the Apple certificate and provisioning profile
+      env:
+        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      run: |
+        # create variables
+        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+        PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+        KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+        # import certificate and provisioning profile from secrets
+        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+        echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+
+        # create temporary keychain
+        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+        # import certificate to keychain
+        security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+        security list-keychain -d user -s $KEYCHAIN_PATH
+
+        # apply provisioning profile
+        mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+        cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
+    - name: Set version in code
+      run: |
+        awk 'NR==3{$0="__version__ = \"'${{ github.ref_name }}'\""}1' ./robusta_krr/__init__.py > temp && mv temp ./robusta_krr/__init__.py
+        cat ./robusta_krr/__init__.py
+
     - name: Build with PyInstaller
-      if: matrix.os != 'macos-latest'
       shell: bash
       run: |
         pyinstaller krr.py
@@ -97,46 +267,37 @@ jobs:
         cp $(python -c "import grapheme; print(grapheme.__path__[0] + '/data/grapheme_break_property.json')") ./dist/krr/grapheme/data/grapheme_break_property.json
         cp ./intro.txt ./dist/krr/intro.txt
 
-    - name: Zip the application (Unix)
-      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15-intel'
+    - name: Zip the application
       run: |
         cd dist
-        zip -r krr-${{ matrix.os }}-${{ github.ref_name }}.zip krr
-        mv krr-${{ matrix.os }}-${{ github.ref_name }}.zip ../
+        zip -r krr-macos-15-intel-${{ github.ref_name }}.zip krr
+        mv krr-macos-15-intel-${{ github.ref_name }}.zip ../
         cd ..
-
-    - name: Zip the application (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        Set-Location -Path dist
-        Compress-Archive -Path krr -DestinationPath krr-${{ matrix.os }}-${{ github.ref_name }}.zip -Force
-        Move-Item -Path krr-${{ matrix.os }}-${{ github.ref_name }}.zip -Destination ..\
-        Set-Location -Path ..
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ github.event.release.upload_url }} 
-        asset_path: ./krr-${{ matrix.os }}-${{ github.ref_name }}.zip
-        asset_name: krr-${{ matrix.os }}-${{ github.ref_name }}.zip
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./krr-macos-15-intel-${{ github.ref_name }}.zip
+        asset_name: krr-macos-15-intel-${{ github.ref_name }}.zip
         asset_content_type: application/octet-stream
 
     - name: Upload build as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: krr-${{ matrix.os }}-${{ github.ref_name }}
-        path: ./krr-${{ matrix.os }}-${{ github.ref_name }}.zip
+        name: krr-macos-15-intel-${{ github.ref_name }}
+        path: ./krr-macos-15-intel-${{ github.ref_name }}.zip
 
     - name: Clean up keychain and provisioning profile
-      if: (matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel') && always()
+      if: always()
       run: |
         security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
         rm ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision
 
   check-latest:
-    needs: build
+    needs: [build-macos, build-ubuntu]
     runs-on: ubuntu-latest
     outputs: 
       IS_LATEST: ${{ steps.check-latest.outputs.release == github.ref_name }}

--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     strategy:
       matrix:
-        # we build on macos-13 for x86 builds
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        # we build on macos-15-intel for x86 builds
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
 
     runs-on: ${{ matrix.os }}
 
@@ -33,7 +33,7 @@ jobs:
         sudo apt-get install -y binutils
 
     - name: Install the Apple certificate and provisioning profile
-      if: matrix.os == 'macos-latest' || matrix.os == 'macos-13' 
+      if: matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel' 
       env:
         BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
         P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
@@ -63,7 +63,7 @@ jobs:
         cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
     - name: Set version in code (Unix)
-      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' 
+      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15-intel' 
       run: |
         awk 'NR==3{$0="__version__ = \"'${{ github.ref_name }}'\""}1' ./robusta_krr/__init__.py > temp && mv temp ./robusta_krr/__init__.py
         cat ./robusta_krr/__init__.py
@@ -98,7 +98,7 @@ jobs:
         cp ./intro.txt ./dist/krr/intro.txt
 
     - name: Zip the application (Unix)
-      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13'
+      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15-intel'
       run: |
         cd dist
         zip -r krr-${{ matrix.os }}-${{ github.ref_name }}.zip krr
@@ -130,7 +130,7 @@ jobs:
         path: ./krr-${{ matrix.os }}-${{ github.ref_name }}.zip
 
     - name: Clean up keychain and provisioning profile
-      if: (matrix.os == 'macos-latest' || matrix.os == 'macos-13') && always()
+      if: (matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel') && always()
       run: |
         security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
         rm ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision
@@ -164,7 +164,7 @@ jobs:
           name: krr-macos-latest-${{ github.ref_name }}
       - name: Calculate hash
         id: calc-hash
-        run: echo "::set-output name=MAC_BUILD_HASH::$(sha256sum krr-macos-latest-${{ github.ref_name }}.zip | awk '{print $1}')"
+        run: echo "MAC_BUILD_HASH=$(sha256sum krr-macos-latest-${{ github.ref_name }}.zip | awk '{print $1}')" >> $GITHUB_OUTPUT
 
   # Define Linux hash job
   linux-hash:
@@ -182,7 +182,7 @@ jobs:
           name: krr-ubuntu-latest-${{ github.ref_name }}
       - name: Calculate hash
         id: calc-hash
-        run: echo "::set-output name=LINUX_BUILD_HASH::$(sha256sum krr-ubuntu-latest-${{ github.ref_name }}.zip | awk '{print $1}')"
+        run: echo "LINUX_BUILD_HASH=$(sha256sum krr-ubuntu-latest-${{ github.ref_name }}.zip | awk '{print $1}')" >> $GITHUB_OUTPUT
 
   # Define job to update homebrew formula
   update-formula:


### PR DESCRIPTION
This pull request refactors the GitHub Actions release build workflow to improve maintainability and reliability. The main change is splitting the previous matrix-based build job into dedicated jobs for each platform (Ubuntu, Windows, macOS ARM, and macOS Intel), and streamlining the build, versioning, artifact upload, and hash calculation steps for each. The workflow also removes redundant hash calculation jobs and updates downstream jobs to use the new outputs.

**Workflow refactoring and platform-specific build jobs:**

* Replaces the matrix-based `build` job with separate jobs: `build-ubuntu`, `build-windows`, `build-macos` (ARM), and `build-macos-intel`, each with tailored steps for setting up Python, installing dependencies, building with PyInstaller, versioning, zipping, and uploading artifacts and release assets. [[1]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L8-R11) [[2]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L31-L36) [[3]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L65-R312)
* Adds in-job hash calculation for Linux and macOS builds, exposing the hash as job outputs for use in downstream jobs. [[1]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L31-L36) [[2]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L65-R312)
* Removes the separate `mac-hash` and `linux-hash` jobs, and updates the `update-formula` job to depend directly on the new build jobs and consume their outputs for hash values. [[1]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L151-R328) [[2]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L199-R338)

**Versioning and artifact handling improvements:**

* Unifies and simplifies the logic for setting the version in `robusta_krr/__init__.py` for each platform, ensuring the release tag is embedded in the build. [[1]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L31-L36) [[2]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L65-R312)
* Ensures that each platform produces a uniquely named zip file and uploads it both as a release asset and as a build artifact. [[1]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L31-L36) [[2]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L65-R312)

**Homebrew formula update:**

* Updates the `update-formula` job to use the new hash outputs from the build jobs, and only runs when the current release is the latest. [[1]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L151-R328) [[2]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747L199-R338)

These changes make the workflow more robust, easier to maintain, and better aligned with platform-specific requirements.