### PR TITLE
Refactor GitHub Actions workflow to use environment variables

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -63,9 +63,11 @@ jobs:
         cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
     - name: Set version in code (Unix)
-      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' 
+      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13'
+      env:
+        GITHUB_REF_NAME: ${{ github.ref_name }}
       run: |
-        awk 'NR==3{$0="__version__ = \"'${{ github.ref_name }}'\""}1' ./robusta_krr/__init__.py > temp && mv temp ./robusta_krr/__init__.py
+        awk -v ver="$GITHUB_REF_NAME" 'NR==3{$0="__version__ = \"" ver "\""}1' ./robusta_krr/__init__.py > temp && mv temp ./robusta_krr/__init__.py
         cat ./robusta_krr/__init__.py
 
     - name: Set version in code (Windows)
@@ -99,18 +101,22 @@ jobs:
 
     - name: Zip the application (Unix)
       if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13'
+      env:
+        GITHUB_REF_NAME: ${{ github.ref_name }}
       run: |
         cd dist
-        zip -r krr-${{ matrix.os }}-${{ github.ref_name }}.zip krr
-        mv krr-${{ matrix.os }}-${{ github.ref_name }}.zip ../
+        zip -r "krr-${{ matrix.os }}-$GITHUB_REF_NAME.zip" krr
+        mv "krr-${{ matrix.os }}-$GITHUB_REF_NAME.zip" ../
         cd ..
 
     - name: Zip the application (Windows)
       if: matrix.os == 'windows-latest'
+      env:
+        GITHUB_REF_NAME: ${{ github.ref_name }}
       run: |
         Set-Location -Path dist
-        Compress-Archive -Path krr -DestinationPath krr-${{ matrix.os }}-${{ github.ref_name }}.zip -Force
-        Move-Item -Path krr-${{ matrix.os }}-${{ github.ref_name }}.zip -Destination ..\
+        Compress-Archive -Path krr -DestinationPath "krr-${{ matrix.os }}-$($env:GITHUB_REF_NAME).zip" -Force
+        Move-Item -Path "krr-${{ matrix.os }}-$($env:GITHUB_REF_NAME).zip" -Destination ..\
         Set-Location -Path ..
 
     - name: Upload Release Asset
@@ -164,7 +170,9 @@ jobs:
           name: krr-macos-latest-${{ github.ref_name }}
       - name: Calculate hash
         id: calc-hash
-        run: echo "::set-output name=MAC_BUILD_HASH::$(sha256sum krr-macos-latest-${{ github.ref_name }}.zip | awk '{print $1}')"
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: echo "::set-output name=MAC_BUILD_HASH::$(sha256sum "krr-macos-latest-$GITHUB_REF_NAME.zip" | awk '{print $1}')"
 
   # Define Linux hash job
   linux-hash:
@@ -182,7 +190,9 @@ jobs:
           name: krr-ubuntu-latest-${{ github.ref_name }}
       - name: Calculate hash
         id: calc-hash
-        run: echo "::set-output name=LINUX_BUILD_HASH::$(sha256sum krr-ubuntu-latest-${{ github.ref_name }}.zip | awk '{print $1}')"
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: echo "::set-output name=LINUX_BUILD_HASH::$(sha256sum "krr-ubuntu-latest-$GITHUB_REF_NAME.zip" | awk '{print $1}')"
 
   # Define job to update homebrew formula
   update-formula:
@@ -195,10 +205,14 @@ jobs:
           repository: robusta-dev/homebrew-krr
           token: ${{ secrets.MULTIREPO_GITHUB_TOKEN }}
       - name: Update krr.rb formula
+        env:
+          MAC_BUILD_HASH_IN: ${{ needs.mac-hash.outputs.MAC_BUILD_HASH }}
+          LINUX_BUILD_HASH_IN: ${{ needs.linux-hash.outputs.LINUX_BUILD_HASH }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          MAC_BUILD_HASH=${{ needs.mac-hash.outputs.MAC_BUILD_HASH }}
-          LINUX_BUILD_HASH=${{ needs.linux-hash.outputs.LINUX_BUILD_HASH }}
-          TAG_NAME=${{ github.ref_name }}
+          MAC_BUILD_HASH="$MAC_BUILD_HASH_IN"
+          LINUX_BUILD_HASH="$LINUX_BUILD_HASH_IN"
+          TAG_NAME="$GITHUB_REF_NAME"
           awk 'NR==6{$0="        url \"https://github.com/robusta-dev/krr/releases/download/'"$TAG_NAME"'/krr-macos-latest-'"$TAG_NAME"'.zip\""}1' ./Formula/krr.rb > temp && mv temp ./Formula/krr.rb
           awk 'NR==7{$0="        sha256 \"'$MAC_BUILD_HASH'\""}1' ./Formula/krr.rb > temp && mv temp ./Formula/krr.rb
           awk 'NR==9{$0="        url \"https://github.com/robusta-dev/krr/releases/download/'"$TAG_NAME"'/krr-ubuntu-latest-'"$TAG_NAME"'.zip\""}1' ./Formula/krr.rb > temp && mv temp ./Formula/krr.rb


### PR DESCRIPTION
## Summary
This PR refactors the build-on-release GitHub Actions workflow to use environment variables instead of directly interpolating GitHub context variables in shell commands. This improves security, readability, and reduces potential issues with special characters in variable values.

## Key Changes
- **Version setting step**: Converted `${{ github.ref_name }}` to use `GITHUB_REF_NAME` environment variable and updated `awk` command to use `-v` flag for safer variable passing
- **Unix zip step**: Moved `github.ref_name` to environment variable and added quotes around filenames to handle special characters
- **Windows zip step**: Converted to use `$env:GITHUB_REF_NAME` PowerShell syntax with proper quoting
- **Hash calculation steps**: Refactored to use environment variables for both macOS and Linux builds, with proper quoting around filenames
- **Homebrew formula update step**: Moved all GitHub context variables (`MAC_BUILD_HASH`, `LINUX_BUILD_HASH`, `github.ref_name`) to environment variables for cleaner script logic

## Implementation Details
- All `${{ github.ref_name }}` references are now passed through `GITHUB_REF_NAME` environment variable
- Added proper quoting around filenames and variables to prevent word splitting and special character issues
- Updated `awk` commands to use `-v` flag for variable passing instead of string interpolation
- Improved PowerShell commands to use `$env:` syntax for environment variable access
- Maintained backward compatibility with existing workflow behavior

https://claude.ai/code/session_01QCBS4ZhVcGUzibiHGxTGVc