### PR TITLE
Fix security vulnerabilities in libattr1 and libacl1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,19 @@ ENV PATH="/app/venv/bin:$PATH"
 RUN apt-get update && \
     dpkg --add-architecture arm64
 
+# Upgrade libattr1 and libacl1 to the fixed versions (CVE-2026-54371 in
+# attr < 2.6.0; CVE-2026-54369 and CVE-2026-54370 in acl < 2.4.0). Trixie has
+# no fixed build yet (fix arrives only in a future point release), so these
+# two leaf libraries are pulled from unstable, pinned low so that nothing
+# else is upgraded from there.
+RUN echo 'deb http://deb.debian.org/debian unstable main' > /etc/apt/sources.list.d/unstable.list \
+    && printf 'Package: *\nPin: release a=unstable\nPin-Priority: 100\n' > /etc/apt/preferences.d/unstable \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends -t unstable libattr1 libacl1 \
+    && rm /etc/apt/sources.list.d/unstable.list /etc/apt/preferences.d/unstable \
+    && dpkg --compare-versions "$(dpkg-query -W -f='${Version}' libattr1)" ge 1:2.6.0 \
+    && dpkg --compare-versions "$(dpkg-query -W -f='${Version}' libacl1)" ge 2.4.0
+
 # Set the working directory
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,13 @@ RUN apt-get update && \
 # Upgrade libattr1 and libacl1 to the fixed versions (CVE-2026-54371 in
 # attr < 2.6.0; CVE-2026-54369 and CVE-2026-54370 in acl < 2.4.0). Trixie has
 # no fixed build yet (fix arrives only in a future point release), so these
-# two leaf libraries are pulled from unstable, pinned low so that nothing
-# else is upgraded from there.
+# two leaf libraries are pulled from unstable via a package-specific pin;
+# everything else in unstable stays at priority 100 so no other package
+# (e.g. libc6) can be upgraded from there.
 RUN echo 'deb http://deb.debian.org/debian unstable main' > /etc/apt/sources.list.d/unstable.list \
-    && printf 'Package: *\nPin: release a=unstable\nPin-Priority: 100\n' > /etc/apt/preferences.d/unstable \
+    && printf 'Package: *\nPin: release a=unstable\nPin-Priority: 100\n\nPackage: libattr1 libacl1\nPin: release a=unstable\nPin-Priority: 990\n' > /etc/apt/preferences.d/unstable \
     && apt-get update \
-    && apt-get install -y --no-install-recommends -t unstable libattr1 libacl1 \
+    && apt-get install -y --no-install-recommends libattr1 libacl1 \
     && rm /etc/apt/sources.list.d/unstable.list /etc/apt/preferences.d/unstable \
     && dpkg --compare-versions "$(dpkg-query -W -f='${Version}' libattr1)" ge 1:2.6.0 \
     && dpkg --compare-versions "$(dpkg-query -W -f='${Version}' libacl1)" ge 2.4.0


### PR DESCRIPTION
## Summary
This change addresses security vulnerabilities in the `libattr1` and `libacl1` packages by upgrading them to fixed versions from the Debian unstable repository.

## Key Changes
- Added a new RUN instruction in the Dockerfile to upgrade `libattr1` (fixes CVE-2026-54371) and `libacl1` (fixes CVE-2026-54369 and CVE-2026-54370)
- Configured the Debian unstable repository as a low-priority source to pull only the fixed versions of these two packages without upgrading other dependencies
- Added version verification checks to ensure the installed versions meet the minimum fixed versions (libattr1 >= 1:2.6.0 and libacl1 >= 2.4.0)
- Cleaned up temporary apt configuration files after installation

## Implementation Details
- The unstable repository is pinned with a priority of 100 (very low) to prevent unintended upgrades of other packages
- Temporary apt sources and preferences files are removed after the upgrade to keep the image clean
- Version checks using `dpkg --compare-versions` validate that the security fixes were successfully applied
- This approach is necessary because Trixie (the current Debian stable) does not yet have these security fixes available

https://claude.ai/code/session_01H47V4EqDNXhaiCMY8iALhS